### PR TITLE
Security: Fix SVG XSS vulnerability (Wordfence CVE-2025-14120)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     },
     "require": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "enshrined/svg-sanitize": "^0.20"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,54 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be0b515f92c17c3a2dcc20581576cfa5",
-    "packages": [],
+    "content-hash": "244eef470469de46e98fcbeaa65a724f",
+    "packages": [
+        {
+            "name": "enshrined/svg-sanitize",
+            "version": "0.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/darylldoyle/svg-sanitizer.git",
+                "reference": "068d9fcf912c88a0471d101d95a2caa87c50aee7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/068d9fcf912c88a0471d101d95a2caa87c50aee7",
+                "reference": "068d9fcf912c88a0471d101d95a2caa87c50aee7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "enshrined\\svgSanitize\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Daryll Doyle",
+                    "email": "daryll@enshrined.co.uk"
+                }
+            ],
+            "description": "An SVG sanitizer for PHP",
+            "support": {
+                "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.20.0"
+            },
+            "time": "2024-09-05T10:18:12+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bww
 Tags: import image, image import, import image to media library, media library, csv import, xml import
 Requires at least: 5.3
 Tested up to: 6.7.1
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 Requires PHP: 7.4
 License: GPLv2 or higher
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -115,6 +115,14 @@ No. [Infinite Uploads](https://wordpress.org/plugins/infinite-uploads/) is an op
 
 == Changelog ==
 
+= 1.0.8 - 12/05/2025 =
+**SECURITY FIX - SVG XSS VULNERABILITY**
+- Fixed: Stored Cross-Site Scripting (XSS) vulnerability via SVG file uploads reported by Wordfence
+- Security: Implemented whitelist-based SVG sanitization using the enshrined/svg-sanitize library
+- Security: Extended fallback blacklist to include SVG animation events (onbegin, onend, onrepeat, onactivate)
+- Security: Added comprehensive coverage for all known SVG XSS vectors including SMIL animation events
+- Security: Added protection against javascript:, data:, and vbscript: URL schemes in SVG attributes
+- Security: Added validation to prevent malicious animate/set elements targeting event handlers
 
 = 1.0.7 - 11/14/2025 =
 - Added **CSV import** functionality for batch image imports from spreadsheets.


### PR DESCRIPTION
- Add enshrined/svg-sanitize library for whitelist-based SVG sanitization
- Extend fallback blacklist to include SVG animation events (onbegin, onend, onrepeat, onactivate)
- Add comprehensive coverage for all known SVG XSS vectors
- Bump version to 1.0.8