### PR TITLE
Update checkout action runtime

### DIFF
--- a/.github/workflows/build-and-zip.yml
+++ b/.github/workflows/build-and-zip.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install SVN
         run: sudo apt-get install -y subversion

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Updates GitHub workflow checkout steps from actions/checkout@v4 to actions/checkout@v6 so the workflows use the newer Node.js runtime and avoid the Node.js 20 deprecation annotation.\n\nValidation:\n- Parsed all workflow YAML files locally.