### PR TITLE
Fix WordPress SVN deploy to honor .distignore (use 10up action)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,35 +14,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Install SVN
-        run: sudo apt-get install -y subversion
-
-      - name: Define Version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Checkout WordPress SVN Repository (Fresh)
-        run: |
-          rm -rf /tmp/wordpress-svn
-          svn checkout https://plugins.svn.wordpress.org/url-image-importer /tmp/wordpress-svn --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache --quiet
-
-      - name: Sync Plugin Files to Trunk
-        run: |
-          rsync -av --delete --exclude=".git" --exclude=".github" --exclude=".gitignore" ./ /tmp/wordpress-svn/trunk/
-          cd /tmp/wordpress-svn
-          svn status | grep '^!' | awk '{print $2}' | xargs svn delete || true
-          svn add --force trunk/
-
-      - name: Commit Changes to Trunk
-        run: |
-          cd /tmp/wordpress-svn
-          svn commit -m "Updating trunk to version $VERSION" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache
-
-      - name: Create New Tag (After Trunk is Committed)
-        run: |
-          cd /tmp/wordpress-svn
-          svn copy trunk tags/$VERSION
-          svn commit -m "Tagging version $VERSION" --username "$SVN_USERNAME" --password "$SVN_PASSWORD" --no-auth-cache
-
-    env:
-      SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-      SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: url-image-importer


### PR DESCRIPTION
## Problem
The deploy workflow used a hand-rolled \`rsync\` that only excluded \`.git\`, \`.github\`, and \`.gitignore\`. It did **not** read \`.distignore\` or \`.gitattributes export-ignore\`, so a tagged release would have shipped \`tests/\`, \`node_modules/\`, \`vendor/\`, and dev config files to the WordPress.org SVN repo.

## Fix
Replace the custom SVN script with \`10up/action-wordpress-plugin-deploy@stable\`, which:
- Honors the existing \`.distignore\` (so \`tests/\` etc. are excluded)
- Handles SVN checkout, trunk sync, and version tagging
- Derives the version from the pushed git tag

## Behavior unchanged
- Still triggers **only** on tag push (\`on: push: tags: '*'\`) — deploys remain manual.
- Same \`SVN_USERNAME\` / \`SVN_PASSWORD\` secrets.
- \`SLUG\` set explicitly to \`url-image-importer\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)