### PR TITLE
Prepare 1.2.1 release

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -298,6 +298,44 @@ input.bfu-input-subscribe {
   position: relative !important;
 }
 
+.media_page_import-images-url .notice {
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.media_page_import-images-url .notice h1,
+.media_page_import-images-url .notice h2,
+.media_page_import-images-url .notice h3,
+.media_page_import-images-url .notice h4,
+.media_page_import-images-url .notice h5,
+.media_page_import-images-url .notice h6 {
+  color: #1d2327;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.media_page_import-images-url .notice h3 {
+  font-size: 1.3em;
+  margin: 1em 0;
+}
+
+.media_page_import-images-url .notice p {
+  font-size: 13px;
+  line-height: 1.5;
+  margin: .5em 0;
+}
+
+.media_page_import-images-url .notice .button {
+  font-size: 13px;
+  line-height: 2.15384615;
+  min-height: 30px;
+  padding: 0 10px;
+}
+
+.media_page_import-images-url .notice .notice-dismiss {
+  padding: 9px;
+}
+
 /* Import Method Styling */
 .import-method {
   background: #fff;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bww
 Tags: import image, image import, import image to media library, media library, csv import, xml import
 Requires at least: 5.3
 Tested up to: 7.0
-Stable tag: 1.2
+Stable tag: 1.2.1
 Requires PHP: 7.4
 License: GPLv2 or higher
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -129,6 +129,9 @@ No. [Infinite Uploads](https://wordpress.org/plugins/infinite-uploads/) is an op
 3. Submit the form. If successful, the image(s) will be added to the Media Library, and you’ll get a link to edit them.
 
 == Changelog ==
+
+= 1.2.1 - 06/13/2026 =
+- Improved ability to import large Google Drive images.
 
 = 1.2 - 05/27/2026 =
 - Added support for importing public Google Drive image file links from the URL importer and CSV importer.

--- a/src/Admin/PromoNotices.php
+++ b/src/Admin/PromoNotices.php
@@ -49,20 +49,19 @@ class PromoNotices {
 
     /**
      * Initialize promotional notices
-     * Note: These notices only show when Big File Uploads is NOT already active
      */
     public function init_notices() {
-        // Big File Form Uploads promotion - only shows if the user doesn't already have it
+        // Infinite Uploads promotion, matching the Big File Uploads upgrade path.
         $this->add_notice([
-            'id' => 'big_file_form_uploads_promo',
-            'title' => __('Complete Your File Management Setup', 'url-image-importer'),
-            'message' => __('You\'re importing images efficiently with URL Image Importer! Now add Big File Form Uploads to handle large file uploads from your website visitors - the perfect complement to your media workflow for better user experience.', 'url-image-importer'),
+            'id' => 'infinite_uploads_promo',
+            'title' => __('Want unlimited storage space?', 'url-image-importer'),
+            'message' => __('Move your media files to the Infinite Uploads cloud to save storage space, bandwidth, improve performance, and free you from hosting limits.', 'url-image-importer'),
             'type' => 'info',
             'buttons' => [
                 'primary' => [
-                    'text' => __('Learn More & Get Big File Form Uploads', 'url-image-importer'),
+                    'text' => __('Learn More About Infinite Uploads', 'url-image-importer'),
                     'action' => 'link',
-                    'link' => 'https://infiniteuploads.com/big-file-form-uploads/',
+                    'link' => self::get_upgrade_url( 'admin_notice' ),
                     'type' => 'primary'
                 ],
                 'maybe_later' => [
@@ -119,8 +118,11 @@ class PromoNotices {
             return;
         }
 
-        // Don't show promotional notices if Big File Uploads is already active
+        // Avoid duplicating the Big File Uploads promotion, and skip when Infinite Uploads is already active.
         if ( function_exists('is_plugin_active') && is_plugin_active('tuxedo-big-file-uploads/tuxedo_big_file_uploads.php') ) {
+            return;
+        }
+        if ( $this->is_infinite_uploads_active() ) {
             return;
         }
 
@@ -175,56 +177,29 @@ class PromoNotices {
                 <span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice', 'url-image-importer' ); ?></span>
             </button>
 
-            <div class="uimptr-notice-content">
-                <div class="uimptr-notice-icon">
-                    <span class="dashicons dashicons-upload" style="font-size: 24px; color: #0073aa;"></span>
-                </div>
-                <div class="uimptr-notice-text">
-                    <h3 style="margin-top: 0;"><?php echo esc_html( $notice['title'] ); ?></h3>
-                    <p><?php echo wp_kses_post( $notice['message'] ); ?></p>
+            <h3><?php echo esc_html( $notice['title'] ); ?></h3>
+            <p><?php echo wp_kses_post( $notice['message'] ); ?></p>
 
-                    <p class="uimptr-notice-actions">
-                        <?php foreach ( $notice['buttons'] as $type => $button ): ?>
-                            <?php if ( empty( $button ) || $type === 'dismiss' ) continue; ?>
-                            <?php
-                            $class = ( isset( $button['type'] ) && $button['type'] === 'primary' ) 
-                                ? 'button-primary' 
-                                : 'button-secondary';
-                            ?>
-                            <button type="button"
-                                    class="button <?php echo esc_attr( $class ); ?>"
-                                    data-action="<?php echo esc_attr( $button['action'] ); ?>"
-                                    <?php if ( ! empty( $button['link'] ) ): ?>
-                                    data-link="<?php echo esc_attr( $button['link'] ); ?>"
-                                    <?php endif; ?>
-                            >
-                                <?php echo esc_html( $button['text'] ); ?>
-                            </button>
-                        <?php endforeach; ?>
-                    </p>
-                </div>
-            </div>
+            <p class="uimptr-notice-actions">
+                <?php foreach ( $notice['buttons'] as $type => $button ): ?>
+                    <?php if ( empty( $button ) || $type === 'dismiss' ) continue; ?>
+                    <?php
+                    $class = ( isset( $button['type'] ) && $button['type'] === 'primary' )
+                        ? 'button-primary'
+                        : 'button-secondary';
+                    ?>
+                    <button type="button"
+                            class="button <?php echo esc_attr( $class ); ?>"
+                            data-action="<?php echo esc_attr( $button['action'] ); ?>"
+                            <?php if ( ! empty( $button['link'] ) ): ?>
+                            data-link="<?php echo esc_attr( $button['link'] ); ?>"
+                            <?php endif; ?>
+                    >
+                        <?php echo esc_html( $button['text'] ); ?>
+                    </button>
+                <?php endforeach; ?>
+            </p>
         </div>
-
-        <style>
-        .uimptr-notice-content {
-            display: flex;
-            align-items: flex-start;
-            gap: 15px;
-            padding-top: 12px;
-        }
-        .uimptr-notice-icon {
-            flex-shrink: 0;
-            margin-top: 5px;
-        }
-        .uimptr-notice-text {
-            flex-grow: 1;
-        }
-        .uimptr-notice-actions .button {
-            margin-right: 10px;
-            margin-bottom: 5px;
-        }
-        </style>
         <?php
     }
 
@@ -249,6 +224,19 @@ class PromoNotices {
             'ajaxurl' => admin_url( 'admin-ajax.php' ),
             'nonce'   => function_exists( '\uimptr_create_ajax_nonce' ) ? \uimptr_create_ajax_nonce() : wp_create_nonce( 'uimptr_ajax' ),
         ] );
+    }
+
+    /**
+     * Check whether Infinite Uploads is already active.
+     *
+     * @return bool
+     */
+    private function is_infinite_uploads_active() {
+        if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'infinite-uploads/infinite-uploads.php' ) ) {
+            return true;
+        }
+
+        return function_exists( 'infinite_uploads_init' ) || class_exists( 'Infinite_Uploads' );
     }
 
 	/**
@@ -316,7 +304,7 @@ class PromoNotices {
 				'utm_medium'   => 'plugin',
 				'utm_campaign' => sanitize_key( $source ),
 			),
-			'https://infiniteuploads.com/big-file-form-uploads/'
+			'https://infiniteuploads.com/'
 		);
 	}
 }

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -28,7 +28,7 @@ class Plugin {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0.3';
+	const VERSION = '1.2.1';
 
 	/**
 	 * Plugin directory path.

--- a/tests/ImageImportTest.php
+++ b/tests/ImageImportTest.php
@@ -75,6 +75,90 @@ class ImageImportTest extends WpTestCase {
 		$this->assertSame( 'hero-image.png', $GLOBALS['uimptr_test_attachment_meta'][ $attachment_id ]['file'] );
 	}
 
+	public function test_import_uses_big_file_uploads_sideload_path_when_available(): void {
+		$GLOBALS['uimptr_test_active_plugins']['tuxedo-big-file-uploads/tuxedo_big_file_uploads.php'] = true;
+
+		$url          = 'https://drive.google.com/file/d/big_drive_image_123/view?usp=sharing';
+		$download_url = \uimptr_get_google_drive_download_url( $url );
+		$this->mockHttpResponse(
+			$download_url,
+			$this->pngBytes(),
+			200,
+			array(
+				'content-type'        => 'image/png',
+				'content-disposition' => 'attachment; filename="Large Drive Image.png"',
+			)
+		);
+
+		$attachment_id = \uimptr_import_image_from_url( $url, null, array( 'title' => 'Large Drive Image.png' ) );
+		$post          = $GLOBALS['uimptr_test_inserted_posts'][ $attachment_id ];
+
+		$this->assertSame( 1001, $attachment_id );
+		$this->assertCount( 1, $GLOBALS['uimptr_test_media_handle_upload_calls'] );
+		$this->assertSame( 'async-upload', $GLOBALS['uimptr_test_media_handle_upload_calls'][0]['file_id'] );
+		$this->assertSame(
+			array(
+				'action'    => 'wp_handle_sideload',
+				'test_form' => false,
+			),
+			$GLOBALS['uimptr_test_media_handle_upload_calls'][0]['overrides']
+		);
+		$this->assertSame( 'Large-Drive-Image.png', basename( $post['file'] ) );
+		$this->assertSame( 'Large Drive Image', $post['post_title'] );
+		$this->assertSame(
+			'https://drive.google.com/file/d/big_drive_image_123/view',
+			$GLOBALS['uimptr_test_post_meta'][ $attachment_id ]['_uimptr_source_url']
+		);
+	}
+
+	public function test_google_drive_big_file_uploads_path_downloads_in_range_chunks(): void {
+		$GLOBALS['uimptr_test_active_plugins']['tuxedo-big-file-uploads/tuxedo_big_file_uploads.php'] = true;
+
+		$url          = 'https://drive.google.com/file/d/chunked_drive_image_123/view?usp=sharing';
+		$download_url = \uimptr_get_google_drive_download_url( $url );
+		$image        = $this->pngBytes() . str_repeat( 'a', 600 );
+		$ranges       = array();
+
+		\add_filter(
+			'uimptr_google_drive_download_chunk_size',
+			function() {
+				return 128;
+			}
+		);
+
+		$GLOBALS['uimptr_test_http_callback'] = function( $request_url, $args ) use ( $download_url, $image, &$ranges ) {
+			$this->assertSame( $download_url, $request_url );
+			$range = $args['headers']['Range'] ?? '';
+			$this->assertMatchesRegularExpression( '/^bytes=\d+-\d+$/', $range );
+
+			$ranges[] = $range;
+			preg_match( '/bytes=(\d+)-(\d+)/', $range, $matches );
+
+			$start = (int) $matches[1];
+			$end   = min( (int) $matches[2], strlen( $image ) - 1 );
+			$body  = substr( $image, $start, $end - $start + 1 );
+
+			return array(
+				'response' => array( 'code' => 206 ),
+				'headers'  => array(
+					'content-type'        => 'image/png',
+					'content-disposition' => 'attachment; filename="Chunked Drive Image.png"',
+					'content-range'       => sprintf( 'bytes %d-%d/%d', $start, $end, strlen( $image ) ),
+					'content-length'      => strlen( $body ),
+				),
+				'body'     => $body,
+			);
+		};
+
+		$attachment_id = \uimptr_import_image_from_url( $url );
+		$post          = $GLOBALS['uimptr_test_inserted_posts'][ $attachment_id ];
+
+		$this->assertGreaterThan( 1, count( $ranges ) );
+		$this->assertSame( 'bytes=0-127', $ranges[0] );
+		$this->assertSame( 'async-upload', $GLOBALS['uimptr_test_media_handle_upload_calls'][0]['file_id'] );
+		$this->assertSame( 'Chunked-Drive-Image.png', basename( $post['file'] ) );
+	}
+
 	public function test_import_infers_extensionless_png_from_content_type(): void {
 		$url = 'https://images.unsplash.com/photo-123';
 		$this->mockHttpResponse( $url, $this->pngBytes(), 200, array( 'content-type' => 'image/png' ) );

--- a/tests/PluginClassTest.php
+++ b/tests/PluginClassTest.php
@@ -39,6 +39,10 @@ class PluginClassTest extends WpTestCase {
 		$this->assertArrayHasKey( 'deactivate', $links );
 		$this->assertStringContainsString( 'upload.php?page=import-images-url', $links['settings'] );
 		$this->assertStringContainsString( 'utm_campaign=plugin_links', $links['upgrade'] );
+		$this->assertStringContainsString( 'https://infiniteuploads.com/', $links['upgrade'] );
+		$this->assertStringContainsString( 'Go Pro', $links['upgrade'] );
+		$this->assertStringNotContainsString( 'InfiniteUploads.com', $links['upgrade'] );
+		$this->assertStringNotContainsString( 'big-file-form-uploads', $links['upgrade'] );
 	}
 
 	public function test_ajax_stop_import_sets_stop_signal_and_stopped_progress(): void {

--- a/tests/PromoNoticesTest.php
+++ b/tests/PromoNoticesTest.php
@@ -11,7 +11,8 @@ class PromoNoticesTest extends WpTestCase {
 		$url = PromoNotices::get_upgrade_url( 'Plugin Links!' );
 		parse_str( (string) parse_url( $url, PHP_URL_QUERY ), $query );
 
-		$this->assertStringStartsWith( 'https://infiniteuploads.com/big-file-form-uploads/', $url );
+		$this->assertStringStartsWith( 'https://infiniteuploads.com/', $url );
+		$this->assertStringNotContainsString( 'big-file-form-uploads', $url );
 		$this->assertSame( 'url_image_importer', $query['utm_source'] );
 		$this->assertSame( 'plugin', $query['utm_medium'] );
 		$this->assertSame( 'pluginlinks', $query['utm_campaign'] );
@@ -24,14 +25,18 @@ class PromoNoticesTest extends WpTestCase {
 		$notices->display_notices();
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'data-notice-id="big_file_form_uploads_promo"', $html );
-		$this->assertStringContainsString( 'Complete Your File Management Setup', $html );
+		$this->assertStringContainsString( 'data-notice-id="infinite_uploads_promo"', $html );
+		$this->assertStringContainsString( 'Want unlimited storage space?', $html );
+		$this->assertStringContainsString( 'Move your media files to the Infinite Uploads cloud', $html );
+		$this->assertStringNotContainsString( 'Big File Form Uploads', $html );
+		$this->assertStringNotContainsString( 'uimptr-notice-content', $html );
+		$this->assertStringNotContainsString( 'uimptr-notice-icon', $html );
 		$this->assertArrayHasKey( 'uimptr-promo-notices', $GLOBALS['uimptr_test_enqueued']['scripts'] );
 		$this->assertSame( 'nonce-uimptr_ajax', $GLOBALS['uimptr_test_enqueued']['localized']['uimptr-promo-notices']['uimptrPromo']['nonce'] );
 	}
 
 	public function test_display_notices_skips_when_user_dismissed_or_plugin_is_active(): void {
-		update_user_meta( 7, 'uimptr_notice_big_file_form_uploads_promo', 'dismissed' );
+		update_user_meta( 7, 'uimptr_notice_infinite_uploads_promo', 'dismissed' );
 		$notices = new PromoNotices();
 
 		ob_start();
@@ -46,31 +51,39 @@ class PromoNoticesTest extends WpTestCase {
 		$notices->display_notices();
 		$html = ob_get_clean();
 		$this->assertSame( '', trim( $html ) );
+
+		\uimptr_tests_reset_environment();
+		$GLOBALS['uimptr_test_active_plugins']['infinite-uploads/infinite-uploads.php'] = true;
+		$notices = new PromoNotices();
+		ob_start();
+		$notices->display_notices();
+		$html = ob_get_clean();
+		$this->assertSame( '', trim( $html ) );
 	}
 
 	public function test_handle_promo_action_records_delay_dismiss_and_link_actions(): void {
 		$notices = new PromoNotices();
 
-		$_POST['notice_id']   = 'big_file_form_uploads_promo';
+		$_POST['notice_id']   = 'infinite_uploads_promo';
 		$_POST['action_type'] = 'delay';
 		$this->callPromoActionExpectingSuccess( $notices );
-		$delay = $GLOBALS['uimptr_test_user_meta'][7]['uimptr_notice_big_file_form_uploads_promo'];
+		$delay = $GLOBALS['uimptr_test_user_meta'][7]['uimptr_notice_infinite_uploads_promo'];
 		$this->assertSame( 'delay', $delay['action'] );
 		$this->assertGreaterThan( time(), $delay['show_after'] );
 
 		$_POST['action_type'] = 'dismiss';
 		$this->callPromoActionExpectingSuccess( $notices );
-		$this->assertSame( 'dismissed', $GLOBALS['uimptr_test_user_meta'][7]['uimptr_notice_big_file_form_uploads_promo'] );
+		$this->assertSame( 'dismissed', $GLOBALS['uimptr_test_user_meta'][7]['uimptr_notice_infinite_uploads_promo'] );
 
 		$_POST['action_type'] = 'link';
 		$this->callPromoActionExpectingSuccess( $notices );
-		$this->assertSame( 'visited', $GLOBALS['uimptr_test_user_meta'][7]['uimptr_notice_big_file_form_uploads_promo'] );
+		$this->assertSame( 'visited', $GLOBALS['uimptr_test_user_meta'][7]['uimptr_notice_infinite_uploads_promo'] );
 	}
 
 	public function test_handle_promo_action_denies_users_without_manage_options(): void {
 		$GLOBALS['uimptr_test_current_user_can'] = false;
 		$notices = new PromoNotices();
-		$_POST['notice_id']   = 'big_file_form_uploads_promo';
+		$_POST['notice_id']   = 'infinite_uploads_promo';
 		$_POST['action_type'] = 'dismiss';
 
 		try {

--- a/tests/UrlInputParsingTest.php
+++ b/tests/UrlInputParsingTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Uimptr\Tests;
+
+use Uimptr\Tests\Support\WpTestCase;
+
+/**
+ * Covers uimptr_parse_image_urls_input(), which splits the "Image URLs"
+ * textarea on newlines and/or commas. Added when the field gained support for
+ * pasted comma-separated lists.
+ */
+class UrlInputParsingTest extends WpTestCase {
+	public function test_splits_newline_separated_urls(): void {
+		$input = "https://example.com/a.jpg\nhttps://example.com/b.jpg";
+
+		$this->assertSame(
+			array( 'https://example.com/a.jpg', 'https://example.com/b.jpg' ),
+			\uimptr_parse_image_urls_input( $input )
+		);
+	}
+
+	public function test_splits_comma_separated_urls(): void {
+		$input = 'https://example.com/a.jpg, https://example.com/b.jpg,https://example.com/c.jpg';
+
+		$this->assertSame(
+			array(
+				'https://example.com/a.jpg',
+				'https://example.com/b.jpg',
+				'https://example.com/c.jpg',
+			),
+			\uimptr_parse_image_urls_input( $input )
+		);
+	}
+
+	public function test_splits_mixed_comma_and_newline_separators(): void {
+		$input = "https://example.com/a.jpg, https://example.com/b.jpg\nhttps://example.com/c.jpg";
+
+		$this->assertSame(
+			array(
+				'https://example.com/a.jpg',
+				'https://example.com/b.jpg',
+				'https://example.com/c.jpg',
+			),
+			\uimptr_parse_image_urls_input( $input )
+		);
+	}
+
+	public function test_trims_whitespace_and_drops_empty_entries(): void {
+		// Trailing comma, blank lines, CRLF newlines and padding around each URL.
+		$input = "  https://example.com/a.jpg  ,\r\n\r\n , https://example.com/b.jpg ,";
+
+		$this->assertSame(
+			array( 'https://example.com/a.jpg', 'https://example.com/b.jpg' ),
+			\uimptr_parse_image_urls_input( $input )
+		);
+	}
+
+	public function test_real_world_google_drive_share_links(): void {
+		// The exact comma-separated paste shape from the support screenshot.
+		$input = 'https://drive.google.com/file/d/1oYofi_W7Y9YfolQb-DzzMRcUmKGw0LB1/view?usp=drive_link, '
+			. 'https://drive.google.com/file/d/1en1Gs2Yqjz7XDuD1Hmh7s-ClFdge7wpC/view?usp=drive_link, '
+			. 'https://drive.google.com/file/d/1RF9cycDqd89ROZWGu3o7MuThKUrbyA5Q/view?usp=drive_link';
+
+		$this->assertSame(
+			array(
+				'https://drive.google.com/file/d/1oYofi_W7Y9YfolQb-DzzMRcUmKGw0LB1/view?usp=drive_link',
+				'https://drive.google.com/file/d/1en1Gs2Yqjz7XDuD1Hmh7s-ClFdge7wpC/view?usp=drive_link',
+				'https://drive.google.com/file/d/1RF9cycDqd89ROZWGu3o7MuThKUrbyA5Q/view?usp=drive_link',
+			),
+			\uimptr_parse_image_urls_input( $input )
+		);
+	}
+
+	public function test_preserves_percent_encoded_commas_within_a_url(): void {
+		// A literal comma inside a URL is percent-encoded (%2C) and must not split.
+		$input = 'https://example.com/img.jpg?list=a%2Cb%2Cc';
+
+		$this->assertSame(
+			array( 'https://example.com/img.jpg?list=a%2Cb%2Cc' ),
+			\uimptr_parse_image_urls_input( $input )
+		);
+	}
+
+	public function test_empty_input_returns_empty_list(): void {
+		$this->assertSame( array(), \uimptr_parse_image_urls_input( '' ) );
+		$this->assertSame( array(), \uimptr_parse_image_urls_input( "  ,\n , \r\n" ) );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -277,9 +277,11 @@ function uimptr_tests_reset_environment() {
 	);
 	$GLOBALS['uimptr_test_temp_dir']         = $temp_dir . '/';
 	$GLOBALS['uimptr_test_http_responses']   = array();
+	$GLOBALS['uimptr_test_http_callback']    = null;
 	$GLOBALS['uimptr_test_inserted_posts']   = array();
 	$GLOBALS['uimptr_test_post_meta']        = array();
 	$GLOBALS['uimptr_test_attachment_meta']  = array();
+	$GLOBALS['uimptr_test_media_handle_upload_calls'] = array();
 	$GLOBALS['uimptr_test_next_post_id']     = 1000;
 	$GLOBALS['uimptr_test_enqueued']         = array( 'styles' => array(), 'scripts' => array(), 'localized' => array() );
 	$GLOBALS['uimptr_test_redirect']         = null;
@@ -1018,6 +1020,58 @@ if ( ! function_exists( 'wp_update_attachment_metadata' ) ) {
 	function wp_update_attachment_metadata( $attachment_id, $data ) {
 		$GLOBALS['uimptr_test_attachment_meta'][ $attachment_id ] = $data;
 		return true;
+	}
+}
+
+if ( ! function_exists( 'media_handle_upload' ) ) {
+	function media_handle_upload( $file_id, $post_id = 0, $post_data = array(), $overrides = array() ) {
+		$GLOBALS['uimptr_test_media_handle_upload_calls'][] = compact( 'file_id', 'post_id', 'post_data', 'overrides' );
+
+		if ( empty( $_FILES[ $file_id ] ) || ! empty( $_FILES[ $file_id ]['error'] ) ) {
+			return new WP_Error( 'upload_error', 'No sideloaded file available.' );
+		}
+
+		$file = $_FILES[ $file_id ];
+		if ( empty( $file['tmp_name'] ) || ! is_readable( $file['tmp_name'] ) ) {
+			return new WP_Error( 'upload_error', 'Sideloaded file is not readable.' );
+		}
+
+		$upload_dir = wp_upload_dir();
+		$filename   = wp_unique_filename( $upload_dir['path'], $file['name'] );
+		$file_path  = trailingslashit( $upload_dir['path'] ) . $filename;
+
+		$moved = @rename( $file['tmp_name'], $file_path );
+		if ( ! $moved ) {
+			$moved = @copy( $file['tmp_name'], $file_path );
+			if ( $moved ) {
+				@unlink( $file['tmp_name'] );
+			}
+		}
+
+		if ( ! $moved ) {
+			return new WP_Error( 'upload_error', 'Failed to move sideloaded file.' );
+		}
+
+		$filetype = wp_check_filetype_and_ext( $file_path, $filename );
+		$attachment = array_merge(
+			array(
+				'post_mime_type' => $filetype['type'],
+				'post_title'     => pathinfo( $filename, PATHINFO_FILENAME ),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+			),
+			$post_data
+		);
+
+		$attachment_id = wp_insert_attachment( $attachment, $file_path, $post_id, true );
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+
+		$attach_data = wp_generate_attachment_metadata( $attachment_id, $file_path );
+		wp_update_attachment_metadata( $attachment_id, $attach_data );
+
+		return $attachment_id;
 	}
 }
 

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -3,14 +3,14 @@
  *
  * Plugin Name: URL Image Importer
  * Description: A plugin to import multiple images into the WordPress Media Library from URLs.
- * Version: 1.2
+ * Version: 1.2.1
  * Author: Infinite Uploads
  * Author URI: https://infiniteuploads.com
  * Text Domain: url-image-importer
  * License: GPL2
  *
  * @package UrlImageImporter
- * @version 1.2
+ * @version 1.2.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $upload_dir = wp_upload_dir();
 
 define( 'UIMPTR_PATH', plugin_dir_path( __FILE__ ) );
-define( 'UIMPTR_VERSION', '1.2' );
+define( 'UIMPTR_VERSION', '1.2.1' );
 
 define( 'UPLOADBLOGSDIR', $upload_dir['basedir'] );  // Use basedir for root uploads folder, not path (current month)
 define( 'UIMPTR_AJAX_NONCE_ACTION', 'uimptr_ajax' );
@@ -914,6 +914,26 @@ function uimptr_handle_xml_import() {
 }
 
 /**
+ * Parse the raw "Image URLs" textarea input into a clean list of URLs.
+ *
+ * Accepts URLs separated by newlines and/or commas (in any combination), trims
+ * surrounding whitespace from each entry, and drops empty entries. Commas are a
+ * safe separator because a comma inside a URL is percent-encoded as %2C.
+ *
+ * @param string $raw Raw textarea value.
+ * @return string[] List of non-empty, trimmed URLs.
+ */
+function uimptr_parse_image_urls_input( $raw ) {
+	$parts = preg_split( '/[\r\n,]+/', (string) $raw );
+
+	if ( false === $parts ) {
+		return array();
+	}
+
+	return array_values( array_filter( array_map( 'trim', $parts ), 'strlen' ) );
+}
+
+/**
  * Import Image Form HTML
  */
 function uimptr_import_images_url_page() {
@@ -933,6 +953,7 @@ function uimptr_import_images_url_page() {
 	// Debug feature: Reset all dismissed notices for testing (add ?undismiss=1 to URL)
 	if ( isset( $_GET['undismiss'] ) && current_user_can( 'manage_options' ) ) {
 		// Reset URL Image Importer specific notices
+		delete_user_meta( get_current_user_id(), 'uimptr_notice_infinite_uploads_promo' );
 		delete_user_meta( get_current_user_id(), 'uimptr_notice_big_file_form_uploads_promo' );
 		
 		// Reset legacy notices if they exist
@@ -952,7 +973,7 @@ function uimptr_import_images_url_page() {
 	// Handle URL Import
 	if ( isset( $_POST['image_urls'] ) ) {
 		check_admin_referer( 'uimptr-form-field', '_wpnonce_select_form' );
-		$image_urls = array_filter( array_map( 'trim', preg_split( '/[\r\n,]+/', sanitize_textarea_field( wp_unslash( $_POST['image_urls'] ) ) ) ) );
+		$image_urls = uimptr_parse_image_urls_input( sanitize_textarea_field( wp_unslash( $_POST['image_urls'] ) ) );
 
 		foreach ( $image_urls as $image_url ) {
 			if ( filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
@@ -1056,11 +1077,15 @@ function uimptr_import_images_url_page() {
 							<button type="button" id="start-url-import" class="btn text-nowrap btn-primary btn-lg"><?php esc_html_e( 'Import Images from URLs', 'url-image-importer' ); ?></button>
 						</div>
 					</div>
-					<p class="description" style="text-align: center; margin-bottom: 10px;">
-						<?php esc_html_e( 'For dedicated high-speed servers, import in runs of 500-2,000 URLs for the best balance of speed and reliability.', 'url-image-importer' ); ?>
-					</p>
-					
-					<!-- Progress Bar for URL Import -->
+						<p class="description" style="text-align: center; margin-bottom: 10px;">
+							<?php esc_html_e( 'For dedicated high-speed servers, import in runs of 500-2,000 URLs for the best balance of speed and reliability.', 'url-image-importer' ); ?>
+						</p>
+						<p class="description" style="text-align: center; margin: 0 0 12px;">
+							<?php esc_html_e( 'Want unlimited storage space, CDN, video hosting, folders, and enhanced media library search?', 'url-image-importer' ); ?>
+							<a href="<?php echo esc_url( admin_url( 'options-general.php?page=big_file_uploads#upgrade-modal' ) ); ?>"><?php esc_html_e( 'Move your media files to the Infinite Uploads cloud.', 'url-image-importer' ); ?></a>
+						</p>
+						
+						<!-- Progress Bar for URL Import -->
 					<div id="url-progress-container" style="display: none; margin-top: 20px;">
 						<div class="progress-info">
 							<span id="url-progress-text">Starting import...</span>
@@ -1131,11 +1156,11 @@ function uimptr_import_images_url_page() {
 							<button type="button" id="start-xml-import" class="btn text-nowrap btn-primary btn-lg"><?php esc_html_e( 'Import from XML File', 'url-image-importer' ); ?></button>
 						</div>
 					</div>
-					<p class="description" style="text-align: center; margin-bottom: 10px;">
-						<?php esc_html_e( 'For dedicated high-speed servers, import in runs of 500-2,000 URLs for the best balance of speed and reliability.', 'url-image-importer' ); ?>
-					</p>
-					
-					<!-- Progress Bar for XML Import -->
+						<p class="description" style="text-align: center; margin-bottom: 10px;">
+							<?php esc_html_e( 'For dedicated high-speed servers, import in runs of 500-2,000 URLs for the best balance of speed and reliability.', 'url-image-importer' ); ?>
+						</p>
+						
+						<!-- Progress Bar for XML Import -->
 					<div id="xml-progress-container" style="display: none; margin-top: 20px;">
 						<div class="progress-info">
 							<span id="xml-progress-text">Processing XML file...</span>
@@ -1212,11 +1237,15 @@ function uimptr_import_images_url_page() {
 						<button type="button" id="start-csv-import" class="btn text-nowrap btn-primary btn-lg"><?php esc_html_e( 'Import from CSV File', 'url-image-importer' ); ?></button>
 					</div>
 				</div>
-				<p class="description" style="text-align: center; margin-bottom: 10px;">
-					<?php esc_html_e( 'For dedicated high-speed servers, import in runs of 500-2,000 URLs for the best balance of speed and reliability.', 'url-image-importer' ); ?>
-				</p>
-				
-				<!-- Progress Bar for CSV Import -->
+					<p class="description" style="text-align: center; margin-bottom: 10px;">
+						<?php esc_html_e( 'For dedicated high-speed servers, import in runs of 500-2,000 URLs for the best balance of speed and reliability.', 'url-image-importer' ); ?>
+					</p>
+					<p class="description" style="text-align: center; margin: 0 0 12px;">
+						<?php esc_html_e( 'Want unlimited storage space, CDN, video hosting, folders, and enhanced media library search?', 'url-image-importer' ); ?>
+						<a href="<?php echo esc_url( admin_url( 'options-general.php?page=big_file_uploads#upgrade-modal' ) ); ?>"><?php esc_html_e( 'Move your media files to the Infinite Uploads cloud.', 'url-image-importer' ); ?></a>
+					</p>
+					
+					<!-- Progress Bar for CSV Import -->
 				<div id="csv-progress-container" style="display: none; margin-top: 20px;">
 					<div class="progress-wrapper">
 						<div class="progress-info">
@@ -2413,6 +2442,337 @@ function uimptr_format_import_skip_message( $url, WP_Error $error ) {
 }
 
 /**
+ * Determine whether Big File Uploads is available for media sideload handling.
+ *
+ * @return bool
+ */
+function uimptr_is_big_file_uploads_active() {
+	if ( class_exists( 'TuxedoBigFileUploads' ) || class_exists( 'UrlBigFileUploads' ) ) {
+		return true;
+	}
+
+	return function_exists( 'is_plugin_active' )
+		&& is_plugin_active( 'tuxedo-big-file-uploads/tuxedo_big_file_uploads.php' );
+}
+
+/**
+ * Load WordPress media upload helpers when they are not already loaded.
+ *
+ * @return bool
+ */
+function uimptr_load_media_upload_dependencies() {
+	$includes = array(
+		'wp-admin/includes/file.php',
+		'wp-admin/includes/media.php',
+		'wp-admin/includes/image.php',
+	);
+
+	foreach ( $includes as $include ) {
+		$path = ABSPATH . $include;
+		if ( file_exists( $path ) ) {
+			require_once $path;
+		}
+	}
+
+	return function_exists( 'media_handle_upload' );
+}
+
+/**
+ * Whether the importer can hand a validated file to the Big File Uploads media path.
+ *
+ * @return bool
+ */
+function uimptr_can_use_big_file_uploads_sideload() {
+	return uimptr_is_big_file_uploads_active() && uimptr_load_media_upload_dependencies();
+}
+
+/**
+ * Get the Big File Uploads temporary directory path.
+ *
+ * @return string
+ */
+function uimptr_get_big_file_uploads_temp_dir() {
+	$default_temp_dir = defined( 'WP_CONTENT_DIR' )
+		? WP_CONTENT_DIR . '/bfu-temp'
+		: trailingslashit( wp_upload_dir()['basedir'] ) . 'bfu-temp';
+
+	return apply_filters( 'bfu_temp_dir', $default_temp_dir );
+}
+
+/**
+ * Get the chunk size used for Google Drive downloads via the BFU path.
+ *
+ * @return int
+ */
+function uimptr_get_big_file_uploads_download_chunk_size() {
+	$kb = defined( 'KB_IN_BYTES' ) ? KB_IN_BYTES : 1024;
+	$mb = defined( 'MB_IN_BYTES' ) ? MB_IN_BYTES : 1048576;
+
+	$chunk_size = defined( 'BIG_FILE_UPLOADS_CHUNK_SIZE_KB' )
+		? (int) BIG_FILE_UPLOADS_CHUNK_SIZE_KB * $kb
+		: 5 * $mb;
+
+	$chunk_size = max( $kb, min( $chunk_size, 5 * $mb ) );
+
+	return (int) apply_filters( 'uimptr_google_drive_download_chunk_size', $chunk_size );
+}
+
+/**
+ * Parse the total size from a Content-Range header.
+ *
+ * @param string $content_range Content-Range header value.
+ * @return int
+ */
+function uimptr_parse_content_range_total_size( $content_range ) {
+	if ( preg_match( '#/(\d+)\s*$#', (string) $content_range, $matches ) ) {
+		return (int) $matches[1];
+	}
+
+	return 0;
+}
+
+/**
+ * Download a Google Drive file in BFU-sized range chunks to the BFU temp dir.
+ *
+ * @param string $download_url Direct Google Drive download URL.
+ * @param string $source_url   Original source URL.
+ * @param array  $metadata     Optional import metadata.
+ * @return array|WP_Error
+ */
+function uimptr_download_google_drive_file_to_big_file_uploads_temp( $download_url, $source_url, $metadata = array() ) {
+	if ( function_exists( 'set_time_limit' ) ) {
+		@set_time_limit( 300 );
+	}
+
+	$temp_dir = uimptr_get_big_file_uploads_temp_dir();
+	$dir_ok   = uimptr_ensure_temp_directory( $temp_dir );
+	if ( is_wp_error( $dir_ok ) ) {
+		return $dir_ok;
+	}
+
+	$chunk_size = uimptr_get_big_file_uploads_download_chunk_size();
+	if ( $chunk_size <= 0 ) {
+		$chunk_size = 1048576;
+	}
+
+	$temp_file = trailingslashit( $temp_dir ) . sprintf(
+		'%d-%s.part',
+		function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 1,
+		sha1( $download_url . microtime( true ) )
+	);
+
+	$handle = @fopen( $temp_file, 'wb' );
+	if ( false === $handle ) {
+		return new WP_Error( 'file_save_failed', 'Failed to open Big File Uploads temporary file.' );
+	}
+
+	$content_type        = '';
+	$content_disposition = '';
+	$total_size          = 0;
+	$offset              = 0;
+	$download_error      = null;
+
+	try {
+		do {
+			$range_end = $total_size > 0 ? min( $offset + $chunk_size - 1, $total_size - 1 ) : $offset + $chunk_size - 1;
+			$response  = wp_remote_get(
+				$download_url,
+				array(
+					'timeout'     => 60,
+					'redirection' => 5,
+					'headers'     => array(
+						'Range' => 'bytes=' . $offset . '-' . $range_end,
+					),
+					'user-agent'  => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ),
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				$download_error = new WP_Error( 'image_download_failed', 'Failed to download Google Drive image chunk: ' . $response->get_error_message() );
+				break;
+			}
+
+			$response_code = wp_remote_retrieve_response_code( $response );
+			if ( ! in_array( $response_code, array( 200, 206 ), true ) ) {
+				$download_error = new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+				break;
+			}
+
+			$body = wp_remote_retrieve_body( $response );
+			if ( '' === $body ) {
+				$download_error = new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+				break;
+			}
+
+			if ( 0 === $offset ) {
+				$content_type        = (string) wp_remote_retrieve_header( $response, 'content-type' );
+				$content_disposition = (string) wp_remote_retrieve_header( $response, 'content-disposition' );
+
+				if ( uimptr_response_looks_like_html( $body, $content_type ) ) {
+					$download_error = new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+					break;
+				}
+
+				$total_size = uimptr_parse_content_range_total_size( (string) wp_remote_retrieve_header( $response, 'content-range' ) );
+				if ( 0 === $total_size && 200 === $response_code ) {
+					$total_size = strlen( $body );
+				}
+			}
+
+			$written = fwrite( $handle, $body );
+			if ( false === $written || $written !== strlen( $body ) ) {
+				$download_error = new WP_Error( 'file_save_failed', 'Failed to write Google Drive image chunk to Big File Uploads temporary file.' );
+				break;
+			}
+
+			$offset += strlen( $body );
+		} while ( $total_size > 0 && $offset < $total_size );
+	} finally {
+		fclose( $handle );
+	}
+
+	if ( is_wp_error( $download_error ) ) {
+		uimptr_delete_file_with_logging( $temp_file, 'failed Google Drive BFU chunk download cleanup' );
+		return $download_error;
+	}
+
+	clearstatcache( true, $temp_file );
+	if ( ! file_exists( $temp_file ) || filesize( $temp_file ) <= 0 ) {
+		uimptr_delete_file_with_logging( $temp_file, 'empty Google Drive BFU temp file cleanup' );
+		return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+	}
+
+	$filename_url_path = is_string( $source_url ) ? parse_url( $source_url, PHP_URL_PATH ) : false;
+	$filename          = $filename_url_path && is_string( $filename_url_path ) ? basename( $filename_url_path ) : '';
+	if ( empty( pathinfo( $filename, PATHINFO_EXTENSION ) ) ) {
+		$header_filename = uimptr_get_filename_from_content_disposition( $content_disposition );
+		if ( ! empty( $header_filename ) ) {
+			$filename = $header_filename;
+		}
+	}
+
+	if ( ! $filename ) {
+		$filename = !empty($metadata['title']) ? sanitize_file_name( $metadata['title'] ) : 'imported_image_' . time();
+	}
+
+	return array(
+		'temp_file'           => $temp_file,
+		'filename'            => sanitize_file_name( $filename ),
+		'content_type'        => $content_type,
+		'content_disposition' => $content_disposition,
+	);
+}
+
+/**
+ * Build attachment post data shared by normal and Big File Uploads imports.
+ *
+ * @param string $title         Attachment title.
+ * @param string $description   Attachment description/caption.
+ * @param string $date          Optional source date.
+ * @param bool   $preserve_dates Whether to preserve source dates.
+ * @param string $mime_type     Attachment mime type.
+ * @return array
+ */
+function uimptr_build_attachment_post_data( $title, $description, $date, $preserve_dates, $mime_type ) {
+	$attachment = array(
+		'post_mime_type' => $mime_type,
+		'post_title'     => $title,
+		'post_name'      => uimptr_sanitize_attachment_slug_from_title( $title ),
+		'post_content'   => $description,
+		'post_excerpt'   => $description,
+		'post_status'    => 'inherit',
+	);
+
+	if ( $preserve_dates && $date ) {
+		$timestamp = strtotime( $date );
+		if ( false !== $timestamp ) {
+			$formatted_date              = date( 'Y-m-d H:i:s', $timestamp );
+			$attachment['post_date']     = $formatted_date;
+			$attachment['post_date_gmt'] = get_gmt_from_date( $formatted_date );
+		} else {
+			error_log( "URL Image Importer: Failed to parse date: {$date}" );
+		}
+	}
+
+	return $attachment;
+}
+
+/**
+ * Apply source URL, title/slug, and alt text metadata after attachment creation.
+ *
+ * @param int    $attachment_id Attachment ID.
+ * @param string $title         Attachment title.
+ * @param array  $metadata      Import metadata.
+ * @param string $image_url     Original source URL.
+ * @return void
+ */
+function uimptr_finalize_imported_attachment( $attachment_id, $title, $metadata, $image_url ) {
+	if ( is_wp_error( $attachment_id ) ) {
+		return;
+	}
+
+	uimptr_update_attachment_title_and_slug( $attachment_id, $title );
+
+	$normalized_source_url = uimptr_normalize_source_url( $image_url );
+	if ( '' !== $normalized_source_url ) {
+		update_post_meta( $attachment_id, '_uimptr_source_url', $normalized_source_url );
+	}
+
+	$alt_text = '';
+	if ( !empty($metadata['alt_text']) ) {
+		$alt_text = sanitize_text_field($metadata['alt_text']);
+	} elseif ( !empty($metadata['title']) ) {
+		$alt_text = $title;
+	}
+
+	if ( !empty($alt_text) ) {
+		update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+	}
+}
+
+/**
+ * Hand a validated temp file to the same sideload path Big File Uploads uses.
+ *
+ * @param string $temp_file  Validated temp file path.
+ * @param string $filename   Final filename.
+ * @param array  $file_type  Validated file type array.
+ * @param array  $post_data  Attachment post data.
+ * @return int|WP_Error
+ */
+function uimptr_import_validated_file_with_big_file_uploads( $temp_file, $filename, array $file_type, array $post_data ) {
+	$previous_files = $_FILES;
+
+	clearstatcache( true, $temp_file );
+	$_FILES['async-upload'] = array(
+		'name'     => $filename,
+		'type'     => $file_type['type'],
+		'tmp_name' => $temp_file,
+		'error'    => UPLOAD_ERR_OK,
+		'size'     => file_exists( $temp_file ) ? filesize( $temp_file ) : 0,
+	);
+
+	try {
+		$attachment_id = media_handle_upload(
+			'async-upload',
+			0,
+			$post_data,
+			array(
+				'action'    => 'wp_handle_sideload',
+				'test_form' => false,
+			)
+		);
+	} finally {
+		$_FILES = $previous_files;
+	}
+
+	if ( is_wp_error( $attachment_id ) && file_exists( $temp_file ) ) {
+		uimptr_delete_file_with_logging( $temp_file, 'failed Big File Uploads sideload cleanup' );
+	}
+
+	return $attachment_id;
+}
+
+/**
  * Function to import the image from a URL
  *
  * @param url   $image_url       URL of the image to import.
@@ -2440,78 +2800,97 @@ function uimptr_import_image_from_url( $image_url, $batch_id = null, $metadata =
 			return $download_url;
 		}
 	}
-	
-	$response = wp_remote_get( $download_url, array(
-		'timeout' => 30,
-		'redirection' => 5,
-		'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' )
-	) );
-	
-	if ( is_wp_error( $response ) ) {
-		return new WP_Error( 'image_download_failed', 'Failed to download image: ' . $response->get_error_message() );
-	}
-
-	$response_code = wp_remote_retrieve_response_code( $response );
-	if ( $response_code !== 200 ) {
-		if ( $is_google_drive_source ) {
-			return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
-		}
-
-		return new WP_Error( 'image_download_failed', sprintf( 'Failed to download image. HTTP status: %d', $response_code ) );
-	}
-
-	$image_data = wp_remote_retrieve_body( $response );
-	
-	if ( empty( $image_data ) ) {
-		if ( $is_google_drive_source ) {
-			return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
-		}
-
-		return new WP_Error( 'invalid_image', 'No data received from URL.' );
-	}
-
-	$response_content_type = (string) wp_remote_retrieve_header( $response, 'content-type' );
-	$response_content_disposition = (string) wp_remote_retrieve_header( $response, 'content-disposition' );
-
-	if ( $is_google_drive_source && uimptr_response_looks_like_html( $image_data, $response_content_type ) ) {
-		return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
-	}
-
-	// Extract filename from URL
 	$upload_dir = wp_upload_dir();
 	$filename_url_path = is_string( $image_url ) ? parse_url( $image_url, PHP_URL_PATH ) : false;
 	$filename = '';
-	
-	if ( $filename_url_path && is_string( $filename_url_path ) ) {
-		$filename = basename( $filename_url_path );
-	}
+	$temp_file = '';
+	$response_content_type = '';
+	$response_content_disposition = '';
 
-	// Prefer a real filename from the HTTP response when the URL path has no extension.
-	if ( empty( pathinfo( $filename, PATHINFO_EXTENSION ) ) ) {
-		$header_filename = uimptr_get_filename_from_content_disposition( $response_content_disposition );
-		if ( ! empty( $header_filename ) ) {
-			$filename = $header_filename;
+	if ( $is_google_drive_source && uimptr_can_use_big_file_uploads_sideload() ) {
+		$downloaded_file = uimptr_download_google_drive_file_to_big_file_uploads_temp( $download_url, $image_url, $metadata );
+		if ( is_wp_error( $downloaded_file ) ) {
+			return $downloaded_file;
+		}
+
+		$temp_file                    = $downloaded_file['temp_file'];
+		$filename                     = $downloaded_file['filename'];
+		$response_content_type        = $downloaded_file['content_type'];
+		$response_content_disposition = $downloaded_file['content_disposition'];
+	} else {
+		$response = wp_remote_get( $download_url, array(
+			'timeout' => 30,
+			'redirection' => 5,
+			'user-agent' => 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' )
+		) );
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'image_download_failed', 'Failed to download image: ' . $response->get_error_message() );
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $response );
+		if ( $response_code !== 200 ) {
+			if ( $is_google_drive_source ) {
+				return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+			}
+
+			return new WP_Error( 'image_download_failed', sprintf( 'Failed to download image. HTTP status: %d', $response_code ) );
+		}
+
+		$image_data = wp_remote_retrieve_body( $response );
+
+		if ( empty( $image_data ) ) {
+			if ( $is_google_drive_source ) {
+				return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+			}
+
+			return new WP_Error( 'invalid_image', 'No data received from URL.' );
+		}
+
+		$response_content_type = (string) wp_remote_retrieve_header( $response, 'content-type' );
+		$response_content_disposition = (string) wp_remote_retrieve_header( $response, 'content-disposition' );
+
+		if ( $is_google_drive_source && uimptr_response_looks_like_html( $image_data, $response_content_type ) ) {
+			return new WP_Error( 'google_drive_not_public_image', 'Google Drive file is not publicly downloadable as an image.' );
+		}
+
+		if ( $filename_url_path && is_string( $filename_url_path ) ) {
+			$filename = basename( $filename_url_path );
+		}
+
+		// Prefer a real filename from the HTTP response when the URL path has no extension.
+		if ( empty( pathinfo( $filename, PATHINFO_EXTENSION ) ) ) {
+			$header_filename = uimptr_get_filename_from_content_disposition( $response_content_disposition );
+			if ( ! empty( $header_filename ) ) {
+				$filename = $header_filename;
+			}
+		}
+
+		// Sanitize filename and ensure it has a base name
+		if ( ! $filename ) {
+			$filename = !empty($metadata['title']) ? sanitize_file_name( $metadata['title'] ) : 'imported_image_' . time();
+		}
+
+		// Sanitize the filename
+		$filename = sanitize_file_name( $filename );
+		$filename_base = pathinfo( $filename, PATHINFO_FILENAME );
+		if ( empty( $filename_base ) ) {
+			$filename_base = !empty($metadata['title']) ? sanitize_file_name( $metadata['title'] ) : 'imported_image_' . time();
+		}
+
+		// Create a temporary file first for validation
+		$temp_file = wp_tempnam( $filename );
+		$saved = file_put_contents( $temp_file, $image_data );
+
+		if ( $saved === false ) {
+			return new WP_Error( 'file_save_failed', 'Failed to save temporary file.' );
 		}
 	}
 
-	// Sanitize filename and ensure it has a base name
-	if ( ! $filename ) {
-		$filename = !empty($metadata['title']) ? sanitize_file_name( $metadata['title'] ) : 'imported_image_' . time();
-	}
-	
-	// Sanitize the filename
 	$filename = sanitize_file_name( $filename );
 	$filename_base = pathinfo( $filename, PATHINFO_FILENAME );
 	if ( empty( $filename_base ) ) {
 		$filename_base = !empty($metadata['title']) ? sanitize_file_name( $metadata['title'] ) : 'imported_image_' . time();
-	}
-	
-	// Create a temporary file first for validation
-	$temp_file = wp_tempnam( $filename );
-	$saved = file_put_contents( $temp_file, $image_data );
-	
-	if ( $saved === false ) {
-		return new WP_Error( 'file_save_failed', 'Failed to save temporary file.' );
 	}
 	
 	// SECURITY: Validate the actual file content using WordPress's image validation
@@ -2632,10 +3011,50 @@ function uimptr_import_image_from_url( $image_url, $batch_id = null, $metadata =
 	}
 	$filename = $filename_base . '.' . $wp_filetype['ext'];
 	$filename = sanitize_file_name( $filename );
+
+	// Use the validated file type.
+	$file_type = array(
+		'ext'  => $wp_filetype['ext'],
+		'type' => $wp_filetype['type']
+	);
+
+	// Use provided metadata when available; otherwise mirror WordPress upload title behavior.
+	if ( !empty($metadata['title']) ) {
+		$title = sanitize_text_field( uimptr_maybe_strip_image_extension_from_title( $metadata['title'] ) );
+	} else {
+		$title_source = $filename;
+		$title_source_without_extension = pathinfo( $filename, PATHINFO_FILENAME );
+		if ( '' !== $title_source_without_extension ) {
+			$title_source = $title_source_without_extension;
+		}
+		$title = sanitize_file_name( $title_source );
+	}
+	$description = !empty($metadata['description']) ? sanitize_textarea_field($metadata['description']) : '';
+	$date = !empty($metadata['date']) ? $metadata['date'] : null;
+	$attachment = uimptr_build_attachment_post_data( $title, $description, $date, $preserve_dates, $file_type['type'] );
+
+	if ( uimptr_can_use_big_file_uploads_sideload() ) {
+		$attachment_id = uimptr_import_validated_file_with_big_file_uploads( $temp_file, $filename, $file_type, $attachment );
+		if ( ! is_wp_error( $attachment_id ) ) {
+			uimptr_finalize_imported_attachment( $attachment_id, $title, $metadata, $image_url );
+		}
+
+		return $attachment_id;
+	}
 	
 	// Generate unique filename to prevent overwrites
 	$filename = wp_unique_filename( $upload_dir['path'], $filename );
 	$file_path = $upload_dir['path'] . '/' . $filename;
+
+	if ( empty( $metadata['title'] ) ) {
+		$title_source = $filename;
+		$title_source_without_extension = pathinfo( $filename, PATHINFO_FILENAME );
+		if ( '' !== $title_source_without_extension ) {
+			$title_source = $title_source_without_extension;
+		}
+		$title      = sanitize_file_name( $title_source );
+		$attachment = uimptr_build_attachment_post_data( $title, $description, $date, $preserve_dates, $file_type['type'] );
+	}
 	
 	// Move the validated temp file to final location
 	// Use copy + unlink instead of rename for cross-filesystem compatibility (cloud storage)
@@ -2654,51 +3073,9 @@ function uimptr_import_image_from_url( $image_url, $batch_id = null, $metadata =
 		return new WP_Error( 'file_move_failed', 'Failed to move validated file to uploads directory.' );
 	}
 	
-	// Use the validated file type
-	$file_type = array(
-		'ext'  => $wp_filetype['ext'],
-		'type' => $wp_filetype['type']
-	);
-	
 	// Verify the file was actually saved and is readable
 	if ( ! file_exists( $file_path ) || ! is_readable( $file_path ) ) {
 		return new WP_Error( 'file_not_accessible', 'Saved file is not accessible.' );
-	}
-
-	// Use provided metadata when available; otherwise mirror WordPress upload title behavior.
-	if ( !empty($metadata['title']) ) {
-		$title = sanitize_text_field( uimptr_maybe_strip_image_extension_from_title( $metadata['title'] ) );
-	} else {
-		$title_source = $filename;
-		$title_source_without_extension = pathinfo( $filename, PATHINFO_FILENAME );
-		if ( '' !== $title_source_without_extension ) {
-			$title_source = $title_source_without_extension;
-		}
-		$title = sanitize_file_name( $title_source );
-	}
-	$description = !empty($metadata['description']) ? sanitize_textarea_field($metadata['description']) : '';
-	$date = !empty($metadata['date']) ? $metadata['date'] : null;
-
-	$attachment = array(
-		'post_mime_type' => $file_type['type'],
-		'post_title'     => $title,
-		'post_name'      => uimptr_sanitize_attachment_slug_from_title( $title ),
-		'post_content'   => $description,
-		'post_excerpt'   => $description, // This becomes the caption
-		'post_status'    => 'inherit',
-	);
-	
-	// Set the original date if available and preserve_dates is enabled
-	if ( $preserve_dates && $date ) {
-		// Handle various date formats from XML/CSV
-		$timestamp = strtotime( $date );
-		if ( $timestamp !== false ) {
-			$formatted_date = date( 'Y-m-d H:i:s', $timestamp );
-			$attachment['post_date'] = $formatted_date;
-			$attachment['post_date_gmt'] = get_gmt_from_date( $formatted_date );
-		} else {
-			error_log( "URL Image Importer: Failed to parse date: {$date}" );
-		}
 	}
 
 	$attachment_id = wp_insert_attachment( $attachment, $file_path );


### PR DESCRIPTION
## Summary
- Bump URL Image Importer to 1.2.1 and update the release changelog
- Improve large Google Drive image imports with Big File Uploads handoff support
- Update Infinite Uploads promo links, notices, and import tab upsell copy
- Add PHPUnit coverage for the Google Drive, promo, and URL parsing changes

## Validation
- composer test
- php -l url-image-importer.php

## Notes
- Tests are included in GitHub for CI, while .distignore excludes them from WordPress.org SVN deploys.
- This PR does not deploy to WordPress.org.