### PR TITLE
Infinite Uploads upsell + scan-flow redesign

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1229,81 +1229,10 @@ body.uimptr-modal-open {
   color: #5b6b7b;
 }
 
-.uimptr-scan__cta {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 13px 26px;
-  background: #26a9e0;
-  border: none;
-  border-radius: 10px;
-  color: #ffffff;
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 1;
-  cursor: pointer;
-  box-shadow: 0 6px 16px rgba(38, 169, 224, 0.28);
-  transition: background-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
-}
-
-.uimptr-scan__cta svg {
-  width: 20px;
-  height: 20px;
-}
-
-.uimptr-scan__cta:hover,
-.uimptr-scan__cta:focus {
-  background: #1c8fbf;
-  color: #ffffff;
-  box-shadow: 0 8px 20px rgba(38, 169, 224, 0.36);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.uimptr-scan__note {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-top: 20px;
-  padding: 15px 18px;
-  max-width: 460px;
-  border: 1px dashed #bcdff0;
-  border-radius: 12px;
-  background: #f6fbfe;
-}
-
-.uimptr-scan__note-icon {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  background: #e6f5fc;
-  color: #26a9e0;
-}
-
-.uimptr-scan__note-icon svg {
-  width: 20px;
-  height: 20px;
-}
-
-.uimptr-scan__note-text {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.uimptr-scan__note-text strong {
-  font-size: 14px;
-  font-weight: 700;
-  color: #1f2d3d;
-}
-
-.uimptr-scan__note-text span {
-  font-size: 13px;
-  color: #7c8a99;
+/* "Run Free Scan" reuses the classic Infinite Uploads button
+   (.btn.btn-primary.btn-lg) so it matches every other IU button. */
+.uimptr-scan__main .btn-primary {
+  margin: 0;
 }
 
 /* Right: feature points with divider */
@@ -1387,10 +1316,258 @@ body.uimptr-modal-open {
     margin-left: auto;
     margin-right: auto;
   }
-  .uimptr-scan__note {
-    text-align: left;
-  }
   .uimptr-scan__features {
     flex-direction: column;
+  }
+}
+
+/* ==========================================================================
+   Subscribe modal (shown after the free scan results) — Infinite Uploads brand
+   ========================================================================== */
+#subscribe-modal .modal-content.uimptr-subscribe {
+  position: relative;
+  border: none;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f5f9ff 0%, #eef4fe 100%);
+  box-shadow: 0 24px 60px rgba(16, 24, 40, 0.22);
+  overflow: hidden;
+}
+
+#subscribe-modal .modal-body {
+  padding: 42px 48px 34px;
+}
+
+.uimptr-subscribe__close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #8a94a6;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.uimptr-subscribe__close svg {
+  width: 20px;
+  height: 20px;
+}
+
+.uimptr-subscribe__close:hover,
+.uimptr-subscribe__close:focus {
+  color: #1f2d3d;
+  outline: none;
+}
+
+.uimptr-subscribe__title {
+  margin: 0 0 10px;
+  text-align: center;
+  font-size: 26px;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #1f2d3d;
+}
+
+.uimptr-subscribe__lead {
+  margin: 0 auto 24px;
+  max-width: 620px;
+  text-align: center;
+  font-size: 15px;
+  line-height: 1.55;
+  color: #5b6b7b;
+}
+
+.uimptr-subscribe__responses {
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.uimptr-subscribe__field {
+  position: relative;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.uimptr-subscribe__field-icon {
+  position: absolute;
+  top: 50%;
+  left: 16px;
+  transform: translateY(-50%);
+  display: flex;
+  color: #26a9e0;
+  pointer-events: none;
+}
+
+.uimptr-subscribe__field-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+#subscribe-modal #mce-EMAIL {
+  width: 100%;
+  height: 54px;
+  margin: 0;
+  padding: 0 18px 0 46px;
+  border: 1px solid #d5e3ef;
+  border-radius: 12px;
+  background: #ffffff;
+  font-size: 15px;
+  text-align: left;
+  color: #1f2d3d;
+  box-shadow: 0 2px 6px rgba(16, 24, 40, 0.05);
+}
+
+#subscribe-modal #mce-EMAIL:focus {
+  border-color: #26a9e0;
+  box-shadow: 0 0 0 3px rgba(38, 169, 224, 0.18);
+  outline: none;
+}
+
+.uimptr-subscribe__fine {
+  margin: 12px 0 22px;
+  text-align: center;
+  font-size: 13px;
+  color: #7c8a99;
+}
+
+.uimptr-subscribe__fine a {
+  color: #26a9e0;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.uimptr-subscribe__fine a:hover,
+.uimptr-subscribe__fine a:focus {
+  text-decoration: underline;
+}
+
+.uimptr-subscribe__actions {
+  text-align: center;
+}
+
+#subscribe-modal #bfu-subscribe-button {
+  min-width: 264px;
+}
+
+.uimptr-subscribe__skip {
+  margin: 16px 0 0;
+  text-align: center;
+  font-size: 13px;
+  color: #7c8a99;
+}
+
+.uimptr-subscribe__skip a {
+  color: #7c8a99;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.uimptr-subscribe__skip a:hover,
+.uimptr-subscribe__skip a:focus {
+  color: #26a9e0;
+  text-decoration: underline;
+}
+
+/* ==========================================================================
+   Scanning modal (scan in progress) — Infinite Uploads brand
+   ========================================================================== */
+#scan-modal .modal-content.uimptr-scanning {
+  position: relative;
+  border: none;
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 24px 60px rgba(16, 24, 40, 0.22);
+  overflow: hidden;
+}
+
+#scan-modal .modal-body {
+  padding: 48px 48px 44px;
+  text-align: center;
+}
+
+.uimptr-scanning__close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #8a94a6;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.uimptr-scanning__close svg {
+  width: 20px;
+  height: 20px;
+}
+
+.uimptr-scanning__close:hover,
+.uimptr-scanning__close:focus {
+  color: #1f2d3d;
+  outline: none;
+}
+
+.uimptr-scanning__spinner {
+  width: 64px;
+  height: 64px;
+  margin: 4px auto 28px;
+  border-radius: 50%;
+  border: 5px solid #e3f3fb;
+  border-top-color: #26a9e0;
+  animation: uimptr-spin 0.9s linear infinite;
+}
+
+@keyframes uimptr-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.uimptr-scanning__title {
+  margin: 0 0 12px;
+  font-size: 24px;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #1f2d3d;
+}
+
+.uimptr-scanning__lead {
+  margin: 0 auto 26px;
+  max-width: 560px;
+  font-size: 15px;
+  line-height: 1.55;
+  color: #5b6b7b;
+}
+
+.uimptr-scanning__progress {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  color: #7c8a99;
+}
+
+#scan-modal #bfu-scan-storage,
+#scan-modal #bfu-scan-files {
+  color: #26a9e0;
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .uimptr-scanning__spinner {
+    animation-duration: 2.4s;
   }
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1144,3 +1144,253 @@ body.uimptr-modal-open {
   vertical-align: text-top;
   color: #26a9e0;
 }
+
+/* ==========================================================================
+   Analyze Your Storage Usage — scan start panel (Infinite Uploads brand)
+   ========================================================================== */
+.uimptr-scan-card {
+  margin-bottom: 24px;
+  border: 1px solid #e6eef4;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(16, 24, 40, 0.05);
+}
+
+.uimptr-scan {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  padding: 32px 36px;
+}
+
+/* Left: progress ring + steps */
+.uimptr-scan__visual {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  width: 180px;
+}
+
+.uimptr-scan__ring {
+  position: relative;
+  width: 158px;
+  height: 158px;
+}
+
+.uimptr-scan__ring-track {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.uimptr-scan__ring-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #26a9e0;
+}
+
+.uimptr-scan__ring-icon svg {
+  width: 54px;
+  height: 54px;
+}
+
+.uimptr-scan__steps {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: #26a9e0;
+}
+
+/* Middle: heading, CTA, fast note */
+.uimptr-scan__main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.uimptr-scan__title {
+  margin: 0 0 8px;
+  padding: 0;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1.15;
+  color: #1f2d3d;
+}
+
+.uimptr-scan__lead {
+  margin: 0 0 22px;
+  max-width: 430px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #5b6b7b;
+}
+
+.uimptr-scan__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 26px;
+  background: #26a9e0;
+  border: none;
+  border-radius: 10px;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(38, 169, 224, 0.28);
+  transition: background-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.uimptr-scan__cta svg {
+  width: 20px;
+  height: 20px;
+}
+
+.uimptr-scan__cta:hover,
+.uimptr-scan__cta:focus {
+  background: #1c8fbf;
+  color: #ffffff;
+  box-shadow: 0 8px 20px rgba(38, 169, 224, 0.36);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.uimptr-scan__note {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 20px;
+  padding: 15px 18px;
+  max-width: 460px;
+  border: 1px dashed #bcdff0;
+  border-radius: 12px;
+  background: #f6fbfe;
+}
+
+.uimptr-scan__note-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: #e6f5fc;
+  color: #26a9e0;
+}
+
+.uimptr-scan__note-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.uimptr-scan__note-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.uimptr-scan__note-text strong {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1f2d3d;
+}
+
+.uimptr-scan__note-text span {
+  font-size: 13px;
+  color: #7c8a99;
+}
+
+/* Right: feature points with divider */
+.uimptr-scan__features {
+  flex: 0 0 auto;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 22px;
+  width: 320px;
+  padding-left: 32px;
+  border-left: 1px solid #e6eef4;
+}
+
+.uimptr-scan__feature {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.uimptr-scan__feature-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  background: #e6f5fc;
+  color: #26a9e0;
+}
+
+.uimptr-scan__feature-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.uimptr-scan__feature-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.uimptr-scan__feature-text strong {
+  font-size: 15px;
+  font-weight: 700;
+  color: #1f2d3d;
+}
+
+.uimptr-scan__feature-text span {
+  font-size: 13px;
+  line-height: 1.45;
+  color: #7c8a99;
+}
+
+@media (max-width: 1120px) {
+  .uimptr-scan {
+    flex-wrap: wrap;
+  }
+  .uimptr-scan__features {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding-left: 0;
+    padding-top: 24px;
+    border-left: none;
+    border-top: 1px solid #e6eef4;
+  }
+  .uimptr-scan__feature {
+    flex: 1 1 230px;
+  }
+}
+
+@media (max-width: 700px) {
+  .uimptr-scan {
+    flex-direction: column;
+    text-align: center;
+  }
+  .uimptr-scan__lead {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .uimptr-scan__note {
+    text-align: left;
+  }
+  .uimptr-scan__features {
+    flex-direction: column;
+  }
+}

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1571,3 +1571,244 @@ body.uimptr-modal-open {
     animation-duration: 2.4s;
   }
 }
+
+/* ==========================================================================
+   Storage Usage Analysis (scan results) — Infinite Uploads brand
+   ========================================================================== */
+.uimptr-results-card {
+  margin-bottom: 24px;
+  border: 1px solid #e6eef4;
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(16, 24, 40, 0.05);
+}
+
+.uimptr-results__header {
+  padding: 20px 30px 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: #1f2d3d;
+}
+
+.uimptr-results {
+  display: flex;
+  align-items: center;
+  gap: 30px;
+  padding: 22px 32px 30px;
+}
+
+/* Left: ring with the total */
+.uimptr-results__visual {
+  flex: 0 0 auto;
+  width: 228px;
+  display: flex;
+  justify-content: center;
+}
+
+.uimptr-results__ring {
+  position: relative;
+  width: 212px;
+  height: 212px;
+}
+
+.uimptr-results__ring-track {
+  display: block;
+  width: 100%;
+  height: 100%;
+  filter: drop-shadow(0 8px 20px rgba(38, 169, 224, 0.10));
+}
+
+.uimptr-results__ring-inner {
+  position: absolute;
+  inset: 0;
+  box-sizing: border-box;
+  padding: 0 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  text-align: center;
+}
+
+.uimptr-results__ring-icon {
+  margin-bottom: 4px;
+  color: #4bb4e6;
+}
+
+.uimptr-results__ring-icon svg {
+  width: 34px;
+  height: 34px;
+}
+
+.uimptr-results__total {
+  font-size: 23px;
+  font-weight: 800;
+  line-height: 1;
+  white-space: nowrap;
+  color: #1f2d3d;
+}
+
+.uimptr-results__total small {
+  font-size: 17px;
+  font-weight: 700;
+  color: #9aa7b4;
+}
+
+.uimptr-results__total-label {
+  margin-top: 2px;
+  font-size: 12px;
+  color: #7c8a99;
+}
+
+/* Right: meta + upgrade card */
+.uimptr-results__main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.uimptr-results__meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.uimptr-results__scanned {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: #7c8a99;
+}
+
+.uimptr-results__scanned svg {
+  width: 15px;
+  height: 15px;
+}
+
+.uimptr-results__refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 15px;
+  border: 1px solid #bcdff0;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #26a9e0;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.uimptr-results__refresh svg {
+  width: 15px;
+  height: 15px;
+}
+
+.uimptr-results__refresh:hover,
+.uimptr-results__refresh:focus {
+  background: #26a9e0;
+  border-color: #26a9e0;
+  color: #ffffff;
+  outline: none;
+}
+
+.uimptr-results__breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 460px;
+  margin-bottom: 20px;
+}
+
+.uimptr-results__type {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.uimptr-results__type-dot {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.uimptr-results__type-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  color: #1f2d3d;
+}
+
+.uimptr-results__type-value {
+  flex: 0 0 auto;
+  font-weight: 700;
+  color: #1f2d3d;
+}
+
+.uimptr-results__upgrade {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 22px 26px;
+  border-radius: 14px;
+  background: #f3f8fd;
+}
+
+.uimptr-results__upgrade-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 2px 10px rgba(16, 24, 40, 0.07);
+}
+
+.uimptr-results__upgrade-icon img {
+  width: 42px;
+  height: 42px;
+}
+
+.uimptr-results__upgrade-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.uimptr-results__upgrade-text h4 {
+  margin: 0 0 6px;
+  font-size: 19px;
+  font-weight: 800;
+  color: #1f2d3d;
+}
+
+.uimptr-results__upgrade-text p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #5b6b7b;
+}
+
+.uimptr-results__upgrade .btn-primary {
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+@media (max-width: 960px) {
+  .uimptr-results {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .uimptr-results__visual {
+    width: 100%;
+  }
+  .uimptr-results__upgrade {
+    flex-direction: column;
+    text-align: center;
+  }
+}

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -60,6 +60,8 @@ body.mobile.modal-open #wpwrap {
   background-color: rgba(38, 169, 224, 0.7) !important;
   border: none !important;
   box-shadow: none !important;
+  /* Keep the pill on <a> buttons — WP core forces a:focus { border-radius: 2px }. */
+  border-radius: 24px;
 }
 
 .btn-primary:active {
@@ -929,6 +931,8 @@ input[type="file"]::-webkit-file-upload-button:hover {
   background: #1c8fbf;
   color: #ffffff !important;
   transform: translateY(-1px);
+  /* Keep the pill on focus — WP core forces a:focus { border-radius: 2px }. */
+  border-radius: 24px;
   box-shadow: 0 8px 20px rgba(38, 169, 224, 0.36);
   outline: none;
 }
@@ -1712,6 +1716,7 @@ body.uimptr-modal-open {
   background: #26a9e0;
   border-color: #26a9e0;
   color: #ffffff;
+  border-radius: 8px;
   outline: none;
 }
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1156,38 +1156,13 @@ body.uimptr-modal-open {
   justify-content: center;
 }
 
-.uimptr-feature-modal__cta {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px 28px;
+/* The modal CTA reuses the classic Infinite Uploads button
+   (.btn.btn-primary.btn-lg) so it matches every other IU button. The
+   explicit radius keeps the rounded pill even though the modal is moved
+   out to <body>, where Bootstrap's .btn-lg could otherwise win. */
+.uimptr-feature-modal__actions .btn {
+  margin: 0;
   border-radius: 24px;
-  background: #26a9e0;
-  color: #ffffff !important;
-  font-size: 15px;
-  font-weight: 700;
-  text-decoration: none;
-  box-shadow: 0 8px 20px rgba(38, 169, 224, 0.3);
-  transition: background-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.uimptr-feature-modal__cta:hover,
-.uimptr-feature-modal__cta:focus {
-  background: #1c8fbf;
-  color: #ffffff !important;
-  transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(38, 169, 224, 0.38);
-  outline: none;
-}
-
-.uimptr-feature-modal__cta-logo {
-  display: inline-flex;
-  line-height: 0;
-}
-
-.uimptr-feature-modal__cta-logo svg {
-  width: 18px;
-  height: 18px;
 }
 
 .uimptr-feature-modal__note {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -298,43 +298,9 @@ input.bfu-input-subscribe {
   position: relative !important;
 }
 
-.media_page_import-images-url .notice {
-  font-size: 13px;
-  line-height: 1.4;
-}
-
-.media_page_import-images-url .notice h1,
-.media_page_import-images-url .notice h2,
-.media_page_import-images-url .notice h3,
-.media_page_import-images-url .notice h4,
-.media_page_import-images-url .notice h5,
-.media_page_import-images-url .notice h6 {
-  color: #1d2327;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.media_page_import-images-url .notice h3 {
-  font-size: 1.3em;
-  margin: 1em 0;
-}
-
-.media_page_import-images-url .notice p {
-  font-size: 13px;
-  line-height: 1.5;
-  margin: .5em 0;
-}
-
-.media_page_import-images-url .notice .button {
-  font-size: 13px;
-  line-height: 2.15384615;
-  min-height: 30px;
-  padding: 0 10px;
-}
-
-.media_page_import-images-url .notice .notice-dismiss {
-  padding: 9px;
-}
+/* The Infinite Uploads promo notice is styled by assets/css/promo-notices.css,
+   which is enqueued on every screen the notice can appear (media, plugins,
+   dashboard), not just this import page. */
 
 /* Import Method Styling */
 .import-method {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -780,3 +780,426 @@ input[type="file"]::-webkit-file-upload-button:hover {
     max-width: 300px;
   }
 }
+
+/* ==========================================================================
+   Infinite Uploads Pro upsell (feature grid + cloud banner)
+   Brand palette: #26a9e0 (primary), #4bc2ec (light), pill CTAs.
+   ========================================================================== */
+.uimptr-upsell-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.uimptr-upsell-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  margin: 0;
+  padding: 20px 64px 20px 20px;
+  background: #ffffff;
+  border: 1px solid #dbe9f1;
+  border-radius: 12px;
+  text-align: left;
+  text-decoration: none;
+  font-family: inherit;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+  transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.uimptr-upsell-card:hover,
+.uimptr-upsell-card:focus {
+  background: #f0fafe;
+  border-color: #a9ddf3;
+  box-shadow: 0 6px 18px rgba(38, 169, 224, 0.15);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.uimptr-upsell-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: #e6f5fc;
+  color: #26a9e0;
+  transition: background-color 0.18s ease;
+}
+
+.uimptr-upsell-card:hover .uimptr-upsell-icon,
+.uimptr-upsell-card:focus .uimptr-upsell-icon {
+  background: #ffffff;
+}
+
+.uimptr-upsell-icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.uimptr-upsell-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.uimptr-upsell-card .uimptr-upsell-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #1f2937;
+  line-height: 1.3;
+}
+
+.uimptr-upsell-desc {
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 1.45;
+}
+
+.uimptr-upsell-badge {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 20px;
+  background: #dff2fb;
+  color: #127ba6;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.uimptr-upsell-lock {
+  width: 11px;
+  height: 11px;
+}
+
+/* Cloud upsell banner */
+.uimptr-cloud-banner {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 20px;
+  padding: 22px 28px;
+  background: linear-gradient(90deg, #e7f6fd 0%, #f4fcfe 55%, #e7f6fd 100%);
+  border: 1px solid #cbe9f7;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.uimptr-cloud-banner__badge {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 1px solid #cbe9f7;
+  box-shadow: 0 4px 12px rgba(38, 169, 224, 0.12);
+}
+
+.uimptr-cloud-banner__badge img {
+  width: 38px;
+  height: auto;
+  display: block;
+}
+
+.uimptr-cloud-banner__content {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.uimptr-cloud-banner__title {
+  display: block;
+  font-size: 22px;
+  font-weight: 800;
+  color: #1f2937;
+  line-height: 1.25;
+}
+
+.uimptr-cloud-banner__subtitle {
+  display: block;
+  margin-top: 6px;
+  font-size: 14px;
+  color: #5b6472;
+  line-height: 1.4;
+}
+
+.uimptr-cloud-banner__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+  padding: 10px 22px;
+  border-radius: 24px;
+  background: #26a9e0;
+  color: #ffffff !important;
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 6px 16px rgba(38, 169, 224, 0.28);
+  transition: background-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.uimptr-cloud-banner__cta:hover,
+.uimptr-cloud-banner__cta:focus {
+  background: #1c8fbf;
+  color: #ffffff !important;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(38, 169, 224, 0.36);
+  outline: none;
+}
+
+.uimptr-cloud-banner__cta svg {
+  width: 16px;
+  height: 16px;
+}
+
+.uimptr-cloud-banner__art {
+  position: absolute;
+  right: 96px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #a9ddf3;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.uimptr-cloud-banner__art svg {
+  width: 150px;
+  height: 150px;
+}
+
+.uimptr-cloud-banner__dismiss {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  display: inline-flex;
+  padding: 4px;
+  background: none;
+  border: none;
+  color: #5b6472;
+  cursor: pointer;
+  line-height: 0;
+  transition: color 0.18s ease;
+}
+
+.uimptr-cloud-banner__dismiss:hover,
+.uimptr-cloud-banner__dismiss:focus {
+  color: #1f2937;
+  outline: none;
+}
+
+.uimptr-cloud-banner__dismiss svg {
+  width: 18px;
+  height: 18px;
+}
+
+@media (max-width: 960px) {
+  .uimptr-upsell-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 782px) {
+  .uimptr-cloud-banner__art {
+    display: none;
+  }
+
+  .uimptr-cloud-banner__title {
+    font-size: 18px;
+  }
+}
+
+@media (max-width: 600px) {
+  .uimptr-upsell-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .uimptr-cloud-banner {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 20px;
+  }
+}
+
+/* Feature detail modal */
+body.uimptr-modal-open {
+  overflow: hidden;
+}
+
+.uimptr-feature-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 100050;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.uimptr-feature-modal.is-open {
+  display: flex;
+}
+
+.uimptr-feature-modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(18, 58, 78, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.uimptr-feature-modal__dialog {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 480px;
+  padding: 36px 36px 30px;
+  background: #ffffff;
+  border-radius: 16px;
+  border-top: 4px solid #26a9e0;
+  box-shadow: 0 24px 60px rgba(16, 24, 40, 0.28);
+  text-align: center;
+  animation: uimptr-modal-in 0.18s ease-out;
+}
+
+@keyframes uimptr-modal-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.uimptr-feature-modal__close {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  display: inline-flex;
+  padding: 6px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: #6b7280;
+  cursor: pointer;
+  line-height: 0;
+  transition: color 0.18s ease, background-color 0.18s ease;
+}
+
+.uimptr-feature-modal__close:hover,
+.uimptr-feature-modal__close:focus {
+  color: #1f2937;
+  background: #eef7fb;
+  outline: none;
+}
+
+.uimptr-feature-modal__close svg {
+  width: 20px;
+  height: 20px;
+}
+
+.uimptr-feature-modal__brand {
+  display: block;
+  width: 132px;
+  height: auto;
+  margin: 0 auto 22px;
+}
+
+.uimptr-feature-modal__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  margin-bottom: 20px;
+  border-radius: 18px;
+  background: #e6f5fc;
+  color: #26a9e0;
+}
+
+.uimptr-feature-modal__icon svg {
+  width: 36px;
+  height: 36px;
+}
+
+.uimptr-feature-modal__heading {
+  margin: 0 0 10px;
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.3;
+  color: #1f2937;
+}
+
+.uimptr-feature-modal__subtitle {
+  margin: 0 0 24px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #5b6472;
+}
+
+.uimptr-feature-modal__actions {
+  display: flex;
+  justify-content: center;
+}
+
+.uimptr-feature-modal__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 28px;
+  border-radius: 24px;
+  background: #26a9e0;
+  color: #ffffff !important;
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(38, 169, 224, 0.3);
+  transition: background-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.uimptr-feature-modal__cta:hover,
+.uimptr-feature-modal__cta:focus {
+  background: #1c8fbf;
+  color: #ffffff !important;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(38, 169, 224, 0.38);
+  outline: none;
+}
+
+.uimptr-feature-modal__cta-logo {
+  display: inline-flex;
+  line-height: 0;
+}
+
+.uimptr-feature-modal__cta-logo svg {
+  width: 18px;
+  height: 18px;
+}
+
+.uimptr-feature-modal__note {
+  margin: 18px 0 0;
+  font-size: 12px;
+  color: #8a92a2;
+}
+
+.uimptr-feature-modal__note .dashicons {
+  font-size: 15px;
+  width: 15px;
+  height: 15px;
+  vertical-align: text-top;
+  color: #26a9e0;
+}

--- a/assets/css/promo-notices.css
+++ b/assets/css/promo-notices.css
@@ -1,0 +1,123 @@
+/**
+ * Infinite Uploads promotional admin notice.
+ *
+ * Styles the notice as a branded card (rounded corners, brand accent bar,
+ * solid brand CTA, text-link secondary) using the Infinite Uploads palette:
+ *   #26a9e0 primary, #1c8fbf hover.
+ * Loaded on every screen the notice can appear (media, plugins, dashboard).
+ */
+
+.uimptr-notice.notice {
+	position: relative;
+	margin: 16px 20px 24px 0;
+	padding: 24px 52px 24px 28px;
+	background: #ffffff;
+	border: 1px solid #e2e8f0;
+	border-left: 6px solid #26a9e0;
+	border-radius: 10px;
+	box-shadow: 0 1px 3px rgba(16, 24, 40, 0.06);
+}
+
+.uimptr-notice.notice h3 {
+	margin: 0 0 10px;
+	padding: 0;
+	font-size: 20px;
+	font-weight: 700;
+	line-height: 1.3;
+	color: #1d2327;
+}
+
+.uimptr-notice.notice p {
+	margin: 0 0 6px;
+	padding: 0;
+	font-size: 14px;
+	line-height: 1.6;
+	color: #50575e;
+}
+
+.uimptr-notice.notice p a {
+	color: #26a9e0;
+	font-weight: 600;
+	text-decoration: none;
+}
+
+.uimptr-notice.notice p a:hover,
+.uimptr-notice.notice p a:focus {
+	color: #1c8fbf;
+	text-decoration: underline;
+}
+
+.uimptr-notice .uimptr-notice-actions {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin: 18px 0 0;
+}
+
+/* Primary "Try for Free" CTA — solid Infinite Uploads brand button. */
+.uimptr-notice .uimptr-notice-actions .button.button-primary {
+	display: inline-flex;
+	align-items: center;
+	height: auto;
+	min-height: 0;
+	padding: 11px 22px;
+	background: #26a9e0;
+	border: none;
+	border-radius: 6px;
+	box-shadow: none;
+	color: #ffffff;
+	font-size: 14px;
+	font-weight: 700;
+	line-height: 1;
+	text-shadow: none;
+	transition: background-color 0.18s ease;
+}
+
+.uimptr-notice .uimptr-notice-actions .button.button-primary:hover,
+.uimptr-notice .uimptr-notice-actions .button.button-primary:focus {
+	background: #1c8fbf;
+	border: none;
+	box-shadow: none;
+	color: #ffffff;
+	outline: none;
+}
+
+/* Secondary "Remind Me Later" — plain brand text link, no button chrome. */
+.uimptr-notice .uimptr-notice-actions .button.button-secondary {
+	height: auto;
+	min-height: 0;
+	padding: 11px 12px;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	color: #26a9e0;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.uimptr-notice .uimptr-notice-actions .button.button-secondary:hover,
+.uimptr-notice .uimptr-notice-actions .button.button-secondary:focus {
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	color: #1c8fbf;
+	text-decoration: underline;
+	outline: none;
+}
+
+/* Dismiss (X) in the top-right corner. */
+.uimptr-notice.notice .notice-dismiss {
+	top: 14px;
+	right: 12px;
+	padding: 9px;
+}
+
+.uimptr-notice.notice .notice-dismiss::before {
+	color: #8a92a2;
+}
+
+.uimptr-notice.notice .notice-dismiss:hover::before,
+.uimptr-notice.notice .notice-dismiss:focus::before {
+	color: #1d2327;
+}

--- a/assets/css/promo-notices.css
+++ b/assets/css/promo-notices.css
@@ -9,8 +9,11 @@
 
 .uimptr-notice.notice {
 	position: relative;
-	margin: 16px 20px 24px 0;
+	/* Full-bleed within .wrap (like the dashboard welcome panel) so the card
+	   never stops short of the content width on wide screens. */
+	margin: 16px 0 24px;
 	padding: 24px 52px 24px 28px;
+	box-sizing: border-box;
 	background: #ffffff;
 	border: 1px solid #e2e8f0;
 	border-left: 6px solid #26a9e0;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -46,6 +46,11 @@ jQuery(document).ready(function ($) {
                 backdrop: 'static',
                 keyboard: false
               });
+            } else {
+              // Already subscribed/dismissed: skip the email modal and just
+              // reload to show the fresh scan results.
+              $('.modal').modal('hide');
+              location.reload();
             }
           return true;
         }
@@ -87,7 +92,7 @@ jQuery(document).ready(function ($) {
       bfu_is_roles(this);
   });
 
-  $('#bfu-view-results').on('click', function () {
+  $('#bfu-view-results, #subscribe-modal .uimptr-subscribe__close').on('click', function () {
     $.post(ajaxurl, {
       action: 'uimptr_subscribe_dismiss',
       nonce: uimptr_ajax.nonce

--- a/src/Admin/PromoNotices.php
+++ b/src/Admin/PromoNotices.php
@@ -52,20 +52,27 @@ class PromoNotices {
      */
     public function init_notices() {
         // Infinite Uploads promotion, matching the Big File Uploads upgrade path.
+        $pricing_url = self::get_pricing_url( 'admin_notice' );
+
         $this->add_notice([
             'id' => 'infinite_uploads_promo',
-            'title' => __('Want unlimited storage space?', 'url-image-importer'),
-            'message' => __('Move your media files to the Infinite Uploads cloud to save storage space, bandwidth, improve performance, and free you from hosting limits.', 'url-image-importer'),
+            'title' => __('Scale Your WordPress Media Library. Upgrade to Infinite Uploads', 'url-image-importer'),
+            'message' => sprintf(
+                /* translators: %1$s: opening link tag for the free-trial link, %2$s: closing link tag. */
+                __('Infinite Uploads adds folders, smart organization, cloud storage, CDN delivery, and media scalability - %1$sStart 7 Day Free Trial%2$s', 'url-image-importer'),
+                '<a href="' . esc_url( $pricing_url ) . '" target="_blank" rel="noopener noreferrer">',
+                '</a>'
+            ),
             'type' => 'info',
             'buttons' => [
                 'primary' => [
-                    'text' => __('Learn More About Infinite Uploads', 'url-image-importer'),
+                    'text' => __('Try for Free', 'url-image-importer'),
                     'action' => 'link',
-                    'link' => self::get_upgrade_url( 'admin_notice' ),
+                    'link' => $pricing_url,
                     'type' => 'primary'
                 ],
                 'maybe_later' => [
-                    'text' => __('Maybe Later', 'url-image-importer'),
+                    'text' => __('Remind Me Later', 'url-image-importer'),
                     'action' => 'delay',
                 ],
                 'dismiss' => [
@@ -305,6 +312,23 @@ class PromoNotices {
 				'utm_campaign' => sanitize_key( $source ),
 			),
 			'https://infiniteuploads.com/'
+		);
+	}
+
+	/**
+	 * Get the Infinite Uploads pricing page URL.
+	 *
+	 * @param string $source Source identifier for tracking.
+	 * @return string
+	 */
+	public static function get_pricing_url( $source = 'plugin' ) {
+		return add_query_arg(
+			array(
+				'utm_source'   => 'url_image_importer',
+				'utm_medium'   => 'plugin',
+				'utm_campaign' => sanitize_key( $source ),
+			),
+			'https://infiniteuploads.com/pricing/'
 		);
 	}
 }

--- a/src/Admin/PromoNotices.php
+++ b/src/Admin/PromoNotices.php
@@ -219,9 +219,23 @@ class PromoNotices {
             return;
         }
 
+        $plugin_root_url  = plugin_dir_url( dirname( dirname( __FILE__ ) ) );
+        $plugin_root_path = plugin_dir_path( dirname( dirname( __FILE__ ) ) );
+
+        // Branded card styling for the notice. Versioned by file mtime so CSS
+        // edits bust the browser cache even when the plugin version is unchanged.
+        $notice_css_path = $plugin_root_path . 'assets/css/promo-notices.css';
+        $notice_css_ver  = file_exists( $notice_css_path ) ? filemtime( $notice_css_path ) : UIMPTR_VERSION;
+        wp_enqueue_style(
+            'uimptr-promo-notice',
+            $plugin_root_url . 'assets/css/promo-notices.css',
+            [],
+            $notice_css_ver
+        );
+
         wp_enqueue_script(
             'uimptr-promo-notices',
-            plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/js/promo-notices.js',
+            $plugin_root_url . 'assets/js/promo-notices.js',
             [ 'jquery' ],
             UIMPTR_VERSION,
             true

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -138,7 +138,11 @@ class Plugin {
 		}
 
 		\wp_enqueue_style( 'uimptr-bootstrap', $this->plugin_url . 'assets/bootstrap/css/bootstrap.min.css', '', self::VERSION );
-		\wp_enqueue_style( 'uimptr-styles', $this->plugin_url . 'assets/css/admin.css', '', self::VERSION );
+		// Version admin.css by file mtime so CSS edits bust the browser cache
+		// even when the plugin version is unchanged.
+		$admin_css_path = $this->plugin_path . 'assets/css/admin.css';
+		$admin_css_ver  = \file_exists( $admin_css_path ) ? \filemtime( $admin_css_path ) : self::VERSION;
+		\wp_enqueue_style( 'uimptr-styles', $this->plugin_url . 'assets/css/admin.css', '', $admin_css_ver );
 		\wp_enqueue_script( 'uimptr-chartjs', $this->plugin_url . 'assets/js/Chart.min.js', '', self::VERSION, true );
 		\wp_enqueue_script( 'bfu-bootstrap', $this->plugin_url . 'assets/bootstrap/js/bootstrap.bundle.min.js', '', self::VERSION, true );
 		\wp_enqueue_script( 'uimptr-js', $this->plugin_url . 'assets/js/admin.js', '', self::VERSION, true );

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -145,7 +145,9 @@ class Plugin {
 		\wp_enqueue_style( 'uimptr-styles', $this->plugin_url . 'assets/css/admin.css', '', $admin_css_ver );
 		\wp_enqueue_script( 'uimptr-chartjs', $this->plugin_url . 'assets/js/Chart.min.js', '', self::VERSION, true );
 		\wp_enqueue_script( 'bfu-bootstrap', $this->plugin_url . 'assets/bootstrap/js/bootstrap.bundle.min.js', '', self::VERSION, true );
-		\wp_enqueue_script( 'uimptr-js', $this->plugin_url . 'assets/js/admin.js', '', self::VERSION, true );
+		$admin_js_path = $this->plugin_path . 'assets/js/admin.js';
+		$admin_js_ver  = \file_exists( $admin_js_path ) ? \filemtime( $admin_js_path ) : self::VERSION;
+		\wp_enqueue_script( 'uimptr-js', $this->plugin_url . 'assets/js/admin.js', '', $admin_js_ver, true );
 
 		$this->localize_scripts();
 	}

--- a/templates/modal-scan.php
+++ b/templates/modal-scan.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Popup for Scan files.
+ * Popup for Scan files (scan in progress).
  *
  * @package UrlImageImporter
  */
@@ -11,46 +11,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="modal fade" id="scan-modal" tabindex="-1" role="dialog" aria-labelledby="scan-modal-label" aria-hidden="true">
 	<div class="modal-dialog modal-dialog-centered modal-lg">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title" id="scan-modal-label"><?php esc_html_e( 'Scanning Files', 'url-image-importer' ); ?></h5>
-				<button type="button" class="close" data-dismiss="modal" aria-label="Close">
-					<span aria-hidden="true">&times;</span>
-				</button>
-			</div>
+		<div class="modal-content uimptr-scanning">
+			<button type="button" class="uimptr-scanning__close" data-dismiss="modal" aria-label="<?php esc_attr_e( 'Close', 'url-image-importer' ); ?>">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+			</button>
 			<div class="modal-body">
-				<div class="container-fluid">
-					<div class="row justify-content-center mb-4 mt-3">
-						<div class="col text-center">
-							<div class="mb-4 mx-auto" style="width: 76px; height: 76px;">
-								<?php
-									require_once UIMPTR_PATH . '/assets/img/spinner-svg.html';
-								?>
-							</div>
-							<h4><?php esc_html_e( 'Scanning Media Library', 'url-image-importer' ); ?></h4>
-							<p class="lead"><?php esc_html_e( 'This usually only takes a minute or two but can take longer for very large media libraries with a lot of files. Please leave this tab open while we complete your scan.', 'url-image-importer' ); ?></p>
-						</div>
-					</div>
-					<div class="row justify-content-center mb-4">
-						<div class="col text-center text-muted">
-							<span class="h5" id="bfu-scan-progress">
-								<?php
-								printf(
-								// translators: %1$s is the opening a tag for storage
-								// translators: %2$s is the closing a tag for storage
-								// translators: %3$s is the opening a tag for files
-								// translators: %4$s is the closing a tag for files.
-									esc_html__( 'Found %1$s0 MB%2$s / %3$s0%4$s Files...', 'url-image-importer' ),
-									'<span id="bfu-scan-storage">',
-									'</span>',
-									'<span id="bfu-scan-files">',
-									'</span>'
-								);
-								?>
-							</span>
-						</div>
-					</div>
-				</div>
+				<div class="uimptr-scanning__spinner" aria-hidden="true"></div>
+				<h4 class="uimptr-scanning__title" id="scan-modal-label"><?php esc_html_e( 'Scanning Media Library', 'url-image-importer' ); ?></h4>
+				<p class="uimptr-scanning__lead"><?php esc_html_e( 'This usually only takes a minute or two but can take longer for very large media libraries with a lot of files. Please leave this tab open while we complete your scan.', 'url-image-importer' ); ?></p>
+				<p class="uimptr-scanning__progress">
+					<span id="bfu-scan-progress">
+						<?php
+						printf(
+						// translators: %1$s is the opening span tag for storage
+						// translators: %2$s is the closing span tag for storage
+						// translators: %3$s is the opening span tag for files
+						// translators: %4$s is the closing span tag for files.
+							esc_html__( 'Found %1$s0 MB%2$s / %3$s0%4$s Files...', 'url-image-importer' ),
+							'<span id="bfu-scan-storage">',
+							'</span>',
+							'<span id="bfu-scan-files">',
+							'</span>'
+						);
+						?>
+					</span>
+				</p>
 			</div>
 		</div>
 	</div>

--- a/templates/modal-subscribe.php
+++ b/templates/modal-subscribe.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="modal fade" id="subscribe-modal" tabindex="-1" role="dialog" aria-labelledby="subscribe-modal-label" aria-hidden="true">
 	<div class="modal-dialog modal-dialog-centered modal-lg">
 		<div class="modal-content uimptr-subscribe">
-			<button type="button" class="uimptr-subscribe__close" data-dismiss="modal" aria-label="<?php esc_attr_e( 'Close', 'url-image-importer' ); ?>">
+			<button type="button" class="uimptr-subscribe__close" aria-label="<?php esc_attr_e( 'Close', 'url-image-importer' ); ?>">
 				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
 			</button>
 			<div class="modal-body">

--- a/templates/modal-subscribe.php
+++ b/templates/modal-subscribe.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Popup for Subscribe.
+ * Popup for Subscribe (shown once the free scan results are ready).
  *
  * @package UrlImageImporter
  */
@@ -10,56 +10,47 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div class="modal fade" id="subscribe-modal" tabindex="-1" role="dialog" aria-labelledby="subscribe-modal-label" aria-hidden="true">
-	
 	<div class="modal-dialog modal-dialog-centered modal-lg">
-		<div class="modal-content">
+		<div class="modal-content uimptr-subscribe">
+			<button type="button" class="uimptr-subscribe__close" data-dismiss="modal" aria-label="<?php esc_attr_e( 'Close', 'url-image-importer' ); ?>">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+			</button>
 			<div class="modal-body">
-				<div class="container-fluid">
-					<form action="https://infiniteuploads.us10.list-manage.com/subscribe/post?u=c50f189b795383e791f477637&amp;id=4f5e536a46&amp;SOURCE=BFU_Plugin" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+				<form action="https://infiniteuploads.us10.list-manage.com/subscribe/post?u=c50f189b795383e791f477637&amp;id=4f5e536a46&amp;SOURCE=BFU_Plugin" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 
-						<div class="row justify-content-center mb-4 mt-3">
-							<div class="col text-center">
-								<h4><?php esc_html_e( 'Get Media Management Tips & Tricks', 'url-image-importer' ); ?></h4>
-								<p class="lead"><?php esc_html_e( 'Subscribe to receive tips for managing large files in WordPress and making your media library infinitely scalable with cloud storage from Infinite Uploads.', 'url-image-importer' ); ?></p>
-							</div>
-						</div>
-						<div class="row">
-							<div class="col text-center">
-								<div id="mce-responses">
-									<div id="mce-error-response" class="response alert alert-warning alert-dismissible fade show" role="alert" style="display:none"></div>
-									<div id="mce-success-response" class="response alert alert-success alert-dismissible fade show" role="alert" style="display:none"></div>
-								</div>
-							</div>
-						</div>
-						<div class="row justify-content-center">
-							<div class="col-xl-8 col-lg-9 col-md-10 text-center">
-									<div style="position: absolute; left: -5000px;" aria-hidden="true">
-										<input type="text" name="b_c50f189b795383e791f477637_4f5e536a46" tabindex="-1" value="">
-									</div>
-									<label for="mce-EMAIL" class="sr-only"><?php esc_html_e( 'Email Address', 'url-image-importer' ); ?></label>
-									<input type="email" value="<?php echo esc_attr( wp_get_current_user()->user_email ); ?>" name="EMAIL" class="required email bfu-input-subscribe" id="mce-EMAIL" placeholder="<?php esc_attr_e( 'Email Address', 'url-image-importer' ); ?>">
-							</div>
-						</div>
-						<div class="row text-center mb-4">
-							<div class="col text-muted">
-								
-							</div>
-						</div>
-						<div class="row justify-content-center mt-4">
-							<div class="col-md-8 col-md-7 col-xl-6 text-center">
-								<button id="bfu-subscribe-button" class="btn text-nowrap btn-primary btn-lg" type="submit"><?php esc_html_e( 'Subscribe & View Results', 'url-image-importer' ); ?></button>
-							</div>
-						</div>
-						<div class="row text-center mb-4">
-							<div class="col text-muted">
-								<small>
-									<a id="bfu-view-results" role="button"><?php esc_html_e( 'No thanks, view results without subscribing.', 'url-image-importer' ); ?></a>
-								</small>
-							</div>
-						</div>
+					<h4 class="uimptr-subscribe__title" id="subscribe-modal-label"><?php esc_html_e( 'Get Media Management Tips & Tricks', 'url-image-importer' ); ?></h4>
+					<p class="uimptr-subscribe__lead"><?php esc_html_e( 'Subscribe to receive tips for managing large files in WordPress and making your media library infinitely scalable with cloud storage from Infinite Uploads.', 'url-image-importer' ); ?></p>
 
-					</form>
-				</div>
+					<div id="mce-responses" class="uimptr-subscribe__responses">
+						<div id="mce-error-response" class="response alert alert-warning alert-dismissible fade show" role="alert" style="display:none"></div>
+						<div id="mce-success-response" class="response alert alert-success alert-dismissible fade show" role="alert" style="display:none"></div>
+					</div>
+
+					<div class="uimptr-subscribe__field">
+						<span class="uimptr-subscribe__field-icon" aria-hidden="true">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+						</span>
+						<div style="position: absolute; left: -5000px;" aria-hidden="true">
+							<input type="text" name="b_c50f189b795383e791f477637_4f5e536a46" tabindex="-1" value="">
+						</div>
+						<label for="mce-EMAIL" class="sr-only"><?php esc_html_e( 'Email Address', 'url-image-importer' ); ?></label>
+						<input type="email" value="<?php echo esc_attr( wp_get_current_user()->user_email ); ?>" name="EMAIL" class="required email bfu-input-subscribe" id="mce-EMAIL" placeholder="<?php esc_attr_e( 'Enter your email', 'url-image-importer' ); ?>">
+					</div>
+
+					<p class="uimptr-subscribe__fine">
+						<?php esc_html_e( 'Optional – no spam, unsubscribe at any time!', 'url-image-importer' ); ?>
+						<a href="<?php echo esc_url( 'https://infiniteuploads.com/privacy/' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Privacy Policy', 'url-image-importer' ); ?></a>
+					</p>
+
+					<div class="uimptr-subscribe__actions">
+						<button id="bfu-subscribe-button" class="btn text-nowrap btn-primary btn-lg" type="submit"><?php esc_html_e( 'Subscribe & View Results', 'url-image-importer' ); ?></button>
+					</div>
+
+					<p class="uimptr-subscribe__skip">
+						<a id="bfu-view-results" role="button"><?php esc_html_e( 'No thanks, view results without subscribing.', 'url-image-importer' ); ?></a>
+					</p>
+
+				</form>
 			</div>
 		</div>
 	</div>

--- a/templates/scan-results.php
+++ b/templates/scan-results.php
@@ -9,7 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$uimptr_iu_cloud = plugins_url( '/assets/img/iu-logo-blue.svg', dirname( __FILE__ ) );
+$uimptr_iu_cloud    = plugins_url( '/assets/img/iu-logo-blue.svg', dirname( __FILE__ ) );
+$uimptr_pricing_url = class_exists( 'UrlImageImporter\\Admin\\PromoNotices' )
+	? UrlImageImporter\Admin\PromoNotices::get_pricing_url( 'scan_results' )
+	: 'https://infiniteuploads.com/pricing/';
 ?>
 <div class="card uimptr-results-card">
 	<div class="uimptr-results__header"><?php esc_html_e( 'Storage Usage Analysis', 'url-image-importer' ); ?></div>
@@ -67,7 +70,7 @@ $uimptr_iu_cloud = plugins_url( '/assets/img/iu-logo-blue.svg', dirname( __FILE_
 					<h4><?php esc_html_e( 'Want unlimited storage space?', 'url-image-importer' ); ?></h4>
 					<p><?php esc_html_e( 'Move your media files to the Infinite Uploads cloud to save storage space, bandwidth, improve performance, and free you from hosting limits.', 'url-image-importer' ); ?></p>
 				</div>
-				<button type="button" class="btn text-nowrap btn-primary btn-lg" data-toggle="modal" data-target="#upgrade-modal"><?php esc_html_e( 'More Info', 'url-image-importer' ); ?></button>
+				<a class="btn text-nowrap btn-primary btn-lg" href="<?php echo esc_url( $uimptr_pricing_url ); ?>" target="_blank" rel="noopener noreferrer" role="button"><?php esc_html_e( 'More Info', 'url-image-importer' ); ?></a>
 			</div>
 		</div>
 

--- a/templates/scan-results.php
+++ b/templates/scan-results.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Popup for Scan Results.
+ * Storage Usage Analysis (scan results).
  *
  * @package UrlImageImporter
  */
@@ -8,58 +8,68 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-?>
-<div class="card">
-	<div class="card-header">
-		<div class="d-flex align-items-center">
-			<h5 class="m-0 mr-auto p-0"><?php esc_html_e( 'Storage Usage Analysis', 'url-image-importer' ); ?></h5>
-		</div>
-	</div>
-	<div class="card-body cloud p-md-5">
-		<div class="row align-items-center justify-content-center mb-5">
-			<div class="col-lg col-xs-12">
-				<p class="lead mb-0"><?php esc_html_e( 'Total Bytes / Files', 'url-image-importer' ); ?></p>
-				<span class="h2 text-nowrap"><?php echo esc_html( size_format( $total_storage, 2 ) ); ?><small class="text-muted"> / <?php echo esc_html( number_format_i18n( $total_files ) ); ?></small></span>
 
-				<div class="container p-0 ml-md-3">
-					<?php foreach ( uimptr_get_filetypes( false ) as $ftype ) { ?>
-						<div class="row mt-2">
-							<div class="col-1"><span class="badge badge-pill" style="background-color: <?php echo esc_html( $ftype->color ); ?>">&nbsp;</span></div>
-							<div class="col-4 lead text-nowrap"><?php echo esc_html( $ftype->label ); ?></div>
-							<div class="col-5 text-nowrap"><strong><?php echo esc_html( size_format( $ftype->size, 2 ) ); ?> / <?php echo esc_html( number_format_i18n( $ftype->files ) ); ?></strong></div>
-						</div>
-					<?php } ?>
-					<div class="row mt-2">
-						<div class="col text-muted">
-							<small>
-								<?php
-									// translators: %1$s is for seconds.
-									printf( esc_html__( 'Scanned %s ago', 'url-image-importer' ), esc_html( human_time_diff( $scan_results['scan_finished'] ) ) );
-								?> &dash;
-								<a href="#" class="badge badge-primary" data-toggle="modal" data-target="#scan-modal">
-									<span data-toggle="tooltip" title="<?php esc_attr_e( 'Run a new scan to detect recently uploaded files.', 'url-image-importer' ); ?>">
-										<?php esc_html_e( 'Refresh', 'url-image-importer' ); ?>
-									</span>
-								</a>
-							</small>
-						</div>
-					</div>
+$uimptr_iu_cloud = plugins_url( '/assets/img/iu-logo-blue.svg', dirname( __FILE__ ) );
+?>
+<div class="card uimptr-results-card">
+	<div class="uimptr-results__header"><?php esc_html_e( 'Storage Usage Analysis', 'url-image-importer' ); ?></div>
+	<div class="uimptr-results">
+
+		<div class="uimptr-results__visual">
+			<div class="uimptr-results__ring">
+				<svg class="uimptr-results__ring-track" viewBox="0 0 200 200" fill="none" aria-hidden="true">
+					<circle cx="100" cy="100" r="82" fill="#ffffff"/>
+					<circle cx="100" cy="100" r="86" stroke="#eaf3fb" stroke-width="10"/>
+					<circle cx="100" cy="16" r="4" fill="#cfe6f6"/>
+					<circle cx="26" cy="64" r="3" fill="#dcecf8"/>
+					<circle cx="174" cy="64" r="3" fill="#dcecf8"/>
+					<circle cx="40" cy="152" r="3.5" fill="#cfe6f6"/>
+					<circle cx="160" cy="152" r="3.5" fill="#cfe6f6"/>
+				</svg>
+				<div class="uimptr-results__ring-inner">
+					<span class="uimptr-results__ring-icon" aria-hidden="true">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+					</span>
+					<span class="uimptr-results__total"><?php echo esc_html( size_format( $total_storage, 2 ) ); ?><small> / <?php echo esc_html( number_format_i18n( $total_files ) ); ?></small></span>
+					<span class="uimptr-results__total-label"><?php esc_html_e( 'Total Bytes / Files', 'url-image-importer' ); ?></span>
 				</div>
 			</div>
-			<div class="col-lg col-xs-12 mt-5 mt-lg-0 text-center bfu-pie-wrapper">
-				<canvas id="bfu-local-pie"></canvas>
+		</div>
+
+		<div class="uimptr-results__main">
+			<div class="uimptr-results__meta">
+				<span class="uimptr-results__scanned">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+					<?php printf( esc_html__( 'Scanned %s ago', 'url-image-importer' ), esc_html( human_time_diff( $scan_results['scan_finished'] ) ) ); ?>
+				</span>
+				<a href="#" class="uimptr-results__refresh" data-toggle="modal" data-target="#scan-modal" title="<?php esc_attr_e( 'Run a new scan to detect recently uploaded files.', 'url-image-importer' ); ?>">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+					<?php esc_html_e( 'Refresh', 'url-image-importer' ); ?>
+				</a>
+			</div>
+
+			<div class="uimptr-results__breakdown">
+				<?php foreach ( uimptr_get_filetypes( false ) as $ftype ) : ?>
+					<?php if ( empty( $ftype->files ) ) { continue; } ?>
+					<div class="uimptr-results__type">
+						<span class="uimptr-results__type-dot" style="background-color: <?php echo esc_attr( $ftype->color ); ?>;"></span>
+						<span class="uimptr-results__type-label"><?php echo esc_html( $ftype->label ); ?></span>
+						<span class="uimptr-results__type-value"><?php echo esc_html( size_format( $ftype->size, 2 ) ); ?> / <?php echo esc_html( number_format_i18n( $ftype->files ) ); ?></span>
+					</div>
+				<?php endforeach; ?>
+			</div>
+
+			<div class="uimptr-results__upgrade">
+				<span class="uimptr-results__upgrade-icon" aria-hidden="true">
+					<img src="<?php echo esc_url( $uimptr_iu_cloud ); ?>" alt="" width="42" height="42" />
+				</span>
+				<div class="uimptr-results__upgrade-text">
+					<h4><?php esc_html_e( 'Want unlimited storage space?', 'url-image-importer' ); ?></h4>
+					<p><?php esc_html_e( 'Move your media files to the Infinite Uploads cloud to save storage space, bandwidth, improve performance, and free you from hosting limits.', 'url-image-importer' ); ?></p>
+				</div>
+				<button type="button" class="btn text-nowrap btn-primary btn-lg" data-toggle="modal" data-target="#upgrade-modal"><?php esc_html_e( 'More Info', 'url-image-importer' ); ?></button>
 			</div>
 		</div>
-		<div class="row justify-content-center mb-3">
-			<div class="col text-center">
-				<h4><?php esc_html_e( 'Want unlimited storage space?', 'url-image-importer' ); ?></h4>
-				<p class="lead"><?php esc_html_e( 'Move your media files to the Infinite Uploads cloud to save storage space, bandwidth, improve performance, and free you from hosting limits.', 'url-image-importer' ); ?></p>
-			</div>
-		</div>
-		<div class="row justify-content-center mb-2">
-			<div class="col text-center">
-				<button class="btn text-nowrap btn-primary btn-lg" data-toggle="modal" data-target="#upgrade-modal"><?php esc_html_e( 'More Info', 'url-image-importer' ); ?></button>
-			</div>
-		</div>
+
 	</div>
 </div>

--- a/templates/scan-start.php
+++ b/templates/scan-start.php
@@ -39,20 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<h2 class="uimptr-scan__title"><?php esc_html_e( 'Analyze Your Storage Usage', 'url-image-importer' ); ?></h2>
 			<p class="uimptr-scan__lead"><?php esc_html_e( 'Run a free scan of your existing Media Library and get your report in seconds.', 'url-image-importer' ); ?></p>
 
-			<button type="button" class="uimptr-scan__cta" data-toggle="modal" data-target="#scan-modal">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
-				<?php esc_html_e( 'Run Free Scan', 'url-image-importer' ); ?>
-			</button>
-
-			<div class="uimptr-scan__note">
-				<span class="uimptr-scan__note-icon" aria-hidden="true">
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-				</span>
-				<span class="uimptr-scan__note-text">
-					<strong><?php esc_html_e( 'Get your report in seconds', 'url-image-importer' ); ?></strong>
-					<span><?php esc_html_e( 'Fast scan. Instant results. No waiting.', 'url-image-importer' ); ?></span>
-				</span>
-			</div>
+			<button type="button" class="btn text-nowrap btn-primary btn-lg" data-toggle="modal" data-target="#scan-modal"><?php esc_html_e( 'Run Free Scan', 'url-image-importer' ); ?></button>
 		</div>
 
 		<div class="uimptr-scan__features">

--- a/templates/scan-start.php
+++ b/templates/scan-start.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Scan start modal.
+ * "Analyze Your Storage Usage" scan start panel.
  *
  * @package UrlImageImporter
  */
@@ -9,18 +9,83 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div class="card">
-	<div class="card-body scan p-md-5">
-		<div class="row justify-content-center mb-3 mt-3">
-			<div class="col text-center">
-				<h2><?php esc_html_e( 'Analyze Your Storage Usage', 'url-image-importer' ); ?></h2>
-				<p class="lead"><?php esc_html_e( 'Run a free scan of your existing Media Library to analyze and visualize storage usage by file type.', 'url-image-importer' ); ?></p>
+<div class="card uimptr-scan-card">
+	<div class="uimptr-scan">
+
+		<div class="uimptr-scan__visual">
+			<div class="uimptr-scan__ring">
+				<svg class="uimptr-scan__ring-track" viewBox="0 0 160 160" fill="none" aria-hidden="true">
+					<circle cx="80" cy="80" r="66" stroke="#e3f3fb" stroke-width="13"/>
+					<circle cx="80" cy="80" r="66" stroke="#26a9e0" stroke-width="13" stroke-linecap="round" stroke-dasharray="414.7" stroke-dashoffset="135" transform="rotate(-90 80 80)"/>
+					<circle cx="80" cy="146" r="4" fill="#26a9e0"/>
+					<circle cx="20" cy="52" r="3" fill="#bce1f4"/>
+					<circle cx="142" cy="60" r="3" fill="#bce1f4"/>
+				</svg>
+				<span class="uimptr-scan__ring-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+						<polyline points="9.5 13.5 11 15 14.5 11.25"/>
+					</svg>
+				</span>
+			</div>
+			<p class="uimptr-scan__steps">
+				<?php esc_html_e( 'Scan', 'url-image-importer' ); ?> &bull;
+				<?php esc_html_e( 'Analyze', 'url-image-importer' ); ?> &bull;
+				<?php esc_html_e( 'Report', 'url-image-importer' ); ?>
+			</p>
+		</div>
+
+		<div class="uimptr-scan__main">
+			<h2 class="uimptr-scan__title"><?php esc_html_e( 'Analyze Your Storage Usage', 'url-image-importer' ); ?></h2>
+			<p class="uimptr-scan__lead"><?php esc_html_e( 'Run a free scan of your existing Media Library and get your report in seconds.', 'url-image-importer' ); ?></p>
+
+			<button type="button" class="uimptr-scan__cta" data-toggle="modal" data-target="#scan-modal">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+				<?php esc_html_e( 'Run Free Scan', 'url-image-importer' ); ?>
+			</button>
+
+			<div class="uimptr-scan__note">
+				<span class="uimptr-scan__note-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+				</span>
+				<span class="uimptr-scan__note-text">
+					<strong><?php esc_html_e( 'Get your report in seconds', 'url-image-importer' ); ?></strong>
+					<span><?php esc_html_e( 'Fast scan. Instant results. No waiting.', 'url-image-importer' ); ?></span>
+				</span>
 			</div>
 		</div>
-		<div class="row justify-content-center mb-2">
-			<div class="col-md-6 col-md-5 col-xl-4 text-center">
-				<button class="btn text-nowrap btn-primary btn-lg" data-toggle="modal" data-target="#scan-modal"><?php esc_html_e( 'Run Scan', 'url-image-importer' ); ?></button>
+
+		<div class="uimptr-scan__features">
+			<div class="uimptr-scan__feature">
+				<span class="uimptr-scan__feature-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+				</span>
+				<span class="uimptr-scan__feature-text">
+					<strong><?php esc_html_e( 'Lightning Fast', 'url-image-importer' ); ?></strong>
+					<span><?php esc_html_e( 'Get your storage usage report in just a few seconds.', 'url-image-importer' ); ?></span>
+				</span>
+			</div>
+
+			<div class="uimptr-scan__feature">
+				<span class="uimptr-scan__feature-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.21 15.89A10 10 0 1 1 8 2.83"/><path d="M22 12A10 10 0 0 0 12 2v10z"/></svg>
+				</span>
+				<span class="uimptr-scan__feature-text">
+					<strong><?php esc_html_e( 'Detailed Insights', 'url-image-importer' ); ?></strong>
+					<span><?php esc_html_e( 'See how your storage is used across different file types.', 'url-image-importer' ); ?></span>
+				</span>
+			</div>
+
+			<div class="uimptr-scan__feature">
+				<span class="uimptr-scan__feature-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+				</span>
+				<span class="uimptr-scan__feature-text">
+					<strong><?php esc_html_e( 'Private &amp; Secure', 'url-image-importer' ); ?></strong>
+					<span><?php esc_html_e( 'We analyze your data locally. Your privacy is our priority.', 'url-image-importer' ); ?></span>
+				</span>
 			</div>
 		</div>
+
 	</div>
 </div>

--- a/tests/PromoNoticesTest.php
+++ b/tests/PromoNoticesTest.php
@@ -46,6 +46,7 @@ class PromoNoticesTest extends WpTestCase {
 		$this->assertStringNotContainsString( 'uimptr-notice-content', $html );
 		$this->assertStringNotContainsString( 'uimptr-notice-icon', $html );
 		$this->assertArrayHasKey( 'uimptr-promo-notices', $GLOBALS['uimptr_test_enqueued']['scripts'] );
+		$this->assertArrayHasKey( 'uimptr-promo-notice', $GLOBALS['uimptr_test_enqueued']['styles'] );
 		$this->assertSame( 'nonce-uimptr_ajax', $GLOBALS['uimptr_test_enqueued']['localized']['uimptr-promo-notices']['uimptrPromo']['nonce'] );
 	}
 

--- a/tests/PromoNoticesTest.php
+++ b/tests/PromoNoticesTest.php
@@ -18,6 +18,16 @@ class PromoNoticesTest extends WpTestCase {
 		$this->assertSame( 'pluginlinks', $query['utm_campaign'] );
 	}
 
+	public function test_pricing_url_points_to_pricing_page_with_tracking(): void {
+		$url = PromoNotices::get_pricing_url( 'Admin Notice!' );
+		parse_str( (string) parse_url( $url, PHP_URL_QUERY ), $query );
+
+		$this->assertStringStartsWith( 'https://infiniteuploads.com/pricing/', $url );
+		$this->assertSame( 'url_image_importer', $query['utm_source'] );
+		$this->assertSame( 'plugin', $query['utm_medium'] );
+		$this->assertSame( 'adminnotice', $query['utm_campaign'] );
+	}
+
 	public function test_display_notices_renders_promo_and_enqueues_script_on_allowed_screen(): void {
 		$notices = new PromoNotices();
 
@@ -26,8 +36,12 @@ class PromoNoticesTest extends WpTestCase {
 		$html = ob_get_clean();
 
 		$this->assertStringContainsString( 'data-notice-id="infinite_uploads_promo"', $html );
-		$this->assertStringContainsString( 'Want unlimited storage space?', $html );
-		$this->assertStringContainsString( 'Move your media files to the Infinite Uploads cloud', $html );
+		$this->assertStringContainsString( 'Scale Your WordPress Media Library. Upgrade to Infinite Uploads', $html );
+		$this->assertStringContainsString( 'Infinite Uploads adds folders, smart organization, cloud storage, CDN delivery, and media scalability', $html );
+		$this->assertStringContainsString( 'Start 7 Day Free Trial', $html );
+		$this->assertStringContainsString( 'Try for Free', $html );
+		$this->assertStringContainsString( 'Remind Me Later', $html );
+		$this->assertStringContainsString( 'infiniteuploads.com/pricing/', $html );
 		$this->assertStringNotContainsString( 'Big File Form Uploads', $html );
 		$this->assertStringNotContainsString( 'uimptr-notice-content', $html );
 		$this->assertStringNotContainsString( 'uimptr-notice-icon', $html );

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -984,9 +984,9 @@ function uimptr_get_infinite_uploads_action() {
 /**
  * Render the Infinite Uploads Pro feature upsell grid.
  *
- * Shared markup displayed on each import tab (URL, XML, CSV). Clicking a feature
- * card opens a modal describing that feature with a branded "Install Infinite
- * Uploads" call to action.
+ * Rendered once per page, beneath the storage analysis section (not inside the
+ * import tabs). Clicking a feature card opens a modal describing that feature
+ * with a branded "Install Infinite Uploads" call to action.
  */
 function uimptr_render_upsell_bar() {
 	// Feather Icons (MIT) rendered inline so no extra assets are required.
@@ -1421,7 +1421,6 @@ function uimptr_import_images_url_page() {
 				</div>
 			</div>
 		</form>
-		<?php uimptr_render_upsell_bar(); ?>
 	</div>
 
 	<!-- XML Import Form -->
@@ -1497,7 +1496,6 @@ function uimptr_import_images_url_page() {
 				</div>
 			</div>
 		</form>
-		<?php uimptr_render_upsell_bar(); ?>
 	</div>
 
 	<!-- CSV Import Section -->
@@ -1584,7 +1582,6 @@ function uimptr_import_images_url_page() {
 				</div>
 			</div>
 		</form>
-		<?php uimptr_render_upsell_bar(); ?>
 	</div>
 
 	<!-- Import Preview Modal -->
@@ -2430,6 +2427,11 @@ function uimptr_import_images_url_page() {
 	} else {
 		require_once UIMPTR_PATH . '/templates/scan-start.php';
 	}
+
+	// Infinite Uploads Pro upsell: rendered once here, beneath the storage
+	// analysis section, instead of being repeated inside each import tab.
+	uimptr_render_upsell_bar();
+
 	require_once UIMPTR_PATH . '/templates/modal-upgrade.php';
 	require_once UIMPTR_PATH . '/templates/footer.php';
 }

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -2404,7 +2404,6 @@ function uimptr_import_images_url_page() {
 	});
 	</script>
 	<?php
-	require_once UIMPTR_PATH . '/templates/scan-start.php';
 	require_once UIMPTR_PATH . '/templates/modal-subscribe.php';
 	require_once UIMPTR_PATH . '/templates/modal-scan.php';
 

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -814,7 +814,11 @@ add_action( 'admin_menu', function() {
 function uimptr_admin_styles() {
 	if ( isset( $_GET['page'] ) && 'import-images-url' === $_GET['page'] ) {
 		wp_enqueue_style( 'uimptr-bootstrap', plugins_url( 'assets/bootstrap/css/bootstrap.min.css', __FILE__ ), '', UIMPTR_VERSION );
-		wp_enqueue_style( 'uimptr-styles', plugins_url( 'assets/css/admin.css', __FILE__ ), '', UIMPTR_VERSION );
+		// Version admin.css by file mtime so CSS edits bust the browser cache
+		// even when the plugin version is unchanged.
+		$uimptr_admin_css     = plugin_dir_path( __FILE__ ) . 'assets/css/admin.css';
+		$uimptr_admin_css_ver = file_exists( $uimptr_admin_css ) ? filemtime( $uimptr_admin_css ) : UIMPTR_VERSION;
+		wp_enqueue_style( 'uimptr-styles', plugins_url( 'assets/css/admin.css', __FILE__ ), '', $uimptr_admin_css_ver );
 		wp_enqueue_script( 'uimptr-chartjs', plugins_url( 'assets/js/Chart.min.js', __FILE__ ), '', UIMPTR_VERSION, true );
 		wp_enqueue_script( 'bfu-bootstrap', plugins_url( 'assets/bootstrap/js/bootstrap.bundle.min.js', __FILE__ ), '', UIMPTR_VERSION, true );
 		wp_enqueue_script( 'uimptr-js', plugins_url( 'assets/js/admin.js', __FILE__ ), '', UIMPTR_VERSION, true );
@@ -1123,17 +1127,11 @@ function uimptr_render_upsell_bar() {
 			<p class="uimptr-feature-modal__subtitle" id="uimptr-feature-modal-subtitle"></p>
 			<div class="uimptr-feature-modal__actions">
 				<?php if ( $action ) : ?>
-					<a class="uimptr-feature-modal__cta" href="<?php echo esc_url( $action['url'] ); ?>"<?php echo $action['external'] ? ' target="_blank" rel="noopener noreferrer"' : ''; ?>>
-						<span class="uimptr-feature-modal__cta-logo" aria-hidden="true">
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
-						</span>
+					<a class="btn text-nowrap btn-primary btn-lg" href="<?php echo esc_url( $action['url'] ); ?>" role="button"<?php echo $action['external'] ? ' target="_blank" rel="noopener noreferrer"' : ''; ?>>
 						<?php echo esc_html( $action['label'] ); ?>
 					</a>
 				<?php else : ?>
-					<a class="uimptr-feature-modal__cta" href="<?php echo esc_url( $learn_more ); ?>" target="_blank" rel="noopener noreferrer">
-						<span class="uimptr-feature-modal__cta-logo" aria-hidden="true">
-							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
-						</span>
+					<a class="btn text-nowrap btn-primary btn-lg" href="<?php echo esc_url( $learn_more ); ?>" role="button" target="_blank" rel="noopener noreferrer">
 						<?php esc_html_e( 'Learn More About Infinite Uploads', 'url-image-importer' ); ?>
 					</a>
 				<?php endif; ?>
@@ -1173,7 +1171,7 @@ function uimptr_render_upsell_bar() {
 			modal.classList.add( 'is-open' );
 			modal.setAttribute( 'aria-hidden', 'false' );
 			document.body.classList.add( 'uimptr-modal-open' );
-			var cta = modal.querySelector( '.uimptr-feature-modal__cta' );
+			var cta = modal.querySelector( '.uimptr-feature-modal__actions .btn' );
 			if ( cta ) {
 				cta.focus();
 			}

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -934,6 +934,317 @@ function uimptr_parse_image_urls_input( $raw ) {
 }
 
 /**
+ * Resolve the Infinite Uploads install / activate / configure action.
+ *
+ * Mirrors the logic in templates/modal-upgrade.php so the upsell surfaces the
+ * same one-click flow the plugin already uses for Infinite Uploads (the cloud
+ * offloading successor to Big File Uploads):
+ *  - not installed  -> core plugin installer (install-plugin)
+ *  - installed only -> activation link
+ *  - active         -> Infinite Uploads settings screen
+ *
+ * @return array{url:string,label:string,external:bool}|null Null when the user
+ *               cannot install plugins.
+ */
+function uimptr_get_infinite_uploads_action() {
+	if ( ! current_user_can( 'install_plugins' ) ) {
+		return null;
+	}
+
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+
+	$plugin_file       = 'infinite-uploads/infinite-uploads.php';
+	$installed_plugins = get_plugins();
+
+	if ( array_key_exists( $plugin_file, $installed_plugins ) ) {
+		if ( class_exists( 'Infinite_Uploads_Admin' ) ) {
+			return array(
+				'url'      => Infinite_Uploads_Admin::get_instance()->settings_url(),
+				'label'    => __( 'Configure Infinite Uploads', 'url-image-importer' ),
+				'external' => false,
+			);
+		}
+
+		return array(
+			'url'      => wp_nonce_url( 'plugins.php?action=activate&plugin=' . rawurlencode( $plugin_file ), 'activate-plugin_' . $plugin_file ),
+			'label'    => __( 'Activate Infinite Uploads', 'url-image-importer' ),
+			'external' => false,
+		);
+	}
+
+	return array(
+		'url'      => wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=infinite-uploads' ), 'install-plugin_infinite-uploads' ),
+		'label'    => __( 'Install Infinite Uploads', 'url-image-importer' ),
+		'external' => false,
+	);
+}
+
+/**
+ * Render the Infinite Uploads Pro feature upsell grid.
+ *
+ * Shared markup displayed on each import tab (URL, XML, CSV). Clicking a feature
+ * card opens a modal describing that feature with a branded "Install Infinite
+ * Uploads" call to action.
+ */
+function uimptr_render_upsell_bar() {
+	// Feather Icons (MIT) rendered inline so no extra assets are required.
+	$features = array(
+		array(
+			'title'    => __( 'Folders', 'url-image-importer' ),
+			'desc'     => __( 'Organize your media files with folders.', 'url-image-importer' ),
+			'heading'  => __( 'Organize your media library with smart folders', 'url-image-importer' ),
+			'subtitle' => __( 'Try Infinite Uploads for free for 7 days and manage your media files with ease.', 'url-image-importer' ),
+			'icon'     => '<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>',
+		),
+		array(
+			'title'    => __( 'Smart Organization', 'url-image-importer' ),
+			'desc'     => __( 'Drag & drop media to keep your library organized.', 'url-image-importer' ),
+			'heading'  => __( 'Keep your media library effortlessly organized', 'url-image-importer' ),
+			'subtitle' => __( 'Try Infinite Uploads for free for 7 days and drag & drop your media into order.', 'url-image-importer' ),
+			'icon'     => '<polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/>',
+		),
+		array(
+			'title'    => __( 'Cloud Storage', 'url-image-importer' ),
+			'desc'     => __( 'Store your media securely in the cloud.', 'url-image-importer' ),
+			'heading'  => __( 'Offload your media to the cloud with Infinite Uploads', 'url-image-importer' ),
+			'subtitle' => __( 'Try Infinite Uploads for free for 7 days and reduce server load while improving performance.', 'url-image-importer' ),
+			'icon'     => '<path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>',
+		),
+		array(
+			'title'    => __( 'CDN Delivery', 'url-image-importer' ),
+			'desc'     => __( 'Deliver media via global CDN for faster sites.', 'url-image-importer' ),
+			'heading'  => __( 'Deliver your media faster worldwide with Global CDN', 'url-image-importer' ),
+			'subtitle' => __( 'Try Infinite Uploads for free for 7 days and serve your media through a global CDN.', 'url-image-importer' ),
+			'icon'     => '<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>',
+		),
+		array(
+			'title'    => __( 'Advanced Search', 'url-image-importer' ),
+			'desc'     => __( 'Find the right media instantly with advanced search.', 'url-image-importer' ),
+			'heading'  => __( 'Find any file instantly with advanced media search', 'url-image-importer' ),
+			'subtitle' => __( 'Try Infinite Uploads for free for 7 days and locate the right media in seconds.', 'url-image-importer' ),
+			'icon'     => '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>',
+		),
+		array(
+			'title'    => __( 'Media Scalability', 'url-image-importer' ),
+			'desc'     => __( 'Handle unlimited growth without limits.', 'url-image-importer' ),
+			'heading'  => __( 'Scale your media storage without limits', 'url-image-importer' ),
+			'subtitle' => __( 'Try Infinite Uploads for free for 7 days and handle unlimited growth effortlessly.', 'url-image-importer' ),
+			'icon'     => '<polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>',
+		),
+	);
+
+	// Feather "lock" icon reused for every Pro badge.
+	$lock_icon = '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>';
+
+	$action     = uimptr_get_infinite_uploads_action();
+	$learn_more = class_exists( 'UrlImageImporter\\Admin\\PromoNotices' )
+		? UrlImageImporter\Admin\PromoNotices::get_upgrade_url( 'feature_modal' )
+		: 'https://infiniteuploads.com/';
+
+	// Official Infinite Uploads brand marks (bundled with the plugin).
+	$iu_logo_mark = plugins_url( 'assets/img/iu-logo-blue.svg', __FILE__ );
+	$iu_wordmark  = plugins_url( 'assets/img/iu-logo-words.svg', __FILE__ );
+	?>
+	<div class="uimptr-upsell-grid">
+		<?php foreach ( $features as $index => $feature ) : ?>
+			<button type="button" class="uimptr-upsell-card" data-uimptr-feature="<?php echo esc_attr( $index ); ?>" aria-haspopup="dialog">
+				<span class="uimptr-upsell-icon" aria-hidden="true">
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><?php echo $feature['icon']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static inline SVG path markup. ?></svg>
+				</span>
+				<span class="uimptr-upsell-text">
+					<span class="uimptr-upsell-title"><?php echo esc_html( $feature['title'] ); ?></span>
+					<span class="uimptr-upsell-desc"><?php echo esc_html( $feature['desc'] ); ?></span>
+				</span>
+				<span class="uimptr-upsell-badge">
+					<?php esc_html_e( 'Pro', 'url-image-importer' ); ?>
+					<svg class="uimptr-upsell-lock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><?php echo $lock_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static inline SVG path markup. ?></svg>
+				</span>
+			</button>
+		<?php endforeach; ?>
+	</div>
+
+	<div class="uimptr-cloud-banner">
+		<span class="uimptr-cloud-banner__badge" aria-hidden="true">
+			<img src="<?php echo esc_url( $iu_logo_mark ); ?>" alt="" width="38" height="29" />
+		</span>
+		<span class="uimptr-cloud-banner__art" aria-hidden="true">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/><polyline points="16 16 12 12 8 16"/><line x1="12" y1="12" x2="12" y2="21"/></svg>
+		</span>
+		<span class="uimptr-cloud-banner__content">
+			<span class="uimptr-cloud-banner__title"><?php esc_html_e( 'You can move your storage to Cloud on Infinite Uploads', 'url-image-importer' ); ?></span>
+			<span class="uimptr-cloud-banner__subtitle"><?php esc_html_e( 'Try out Infinite Uploads for Free for 7 days and upload your storage to the cloud.', 'url-image-importer' ); ?></span>
+			<?php if ( $action ) : ?>
+				<a class="uimptr-cloud-banner__cta" href="<?php echo esc_url( $action['url'] ); ?>">
+					<?php esc_html_e( 'Start Free', 'url-image-importer' ); ?>
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+				</a>
+			<?php else : ?>
+				<a class="uimptr-cloud-banner__cta" href="<?php echo esc_url( $learn_more ); ?>" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Start Free', 'url-image-importer' ); ?>
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+				</a>
+			<?php endif; ?>
+		</span>
+		<button type="button" class="uimptr-cloud-banner__dismiss" aria-label="<?php esc_attr_e( 'Dismiss', 'url-image-importer' ); ?>">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+		</button>
+	</div>
+	<?php
+	// The feature modal, dismiss handler and click wiring only need to exist once,
+	// even though this helper renders on all three import tabs.
+	static $singletons_printed = false;
+	if ( $singletons_printed ) {
+		return;
+	}
+	$singletons_printed = true;
+
+	// Feature data for the modal, keyed by the card index. Only presentational
+	// text and the icon differ per feature; the install action is shared.
+	$modal_features = array();
+	foreach ( $features as $index => $feature ) {
+		$modal_features[ $index ] = array(
+			'heading'  => $feature['heading'],
+			'subtitle' => $feature['subtitle'],
+			'icon'     => $feature['icon'],
+		);
+	}
+	?>
+	<div class="uimptr-feature-modal" id="uimptr-feature-modal" aria-hidden="true">
+		<div class="uimptr-feature-modal__overlay" data-uimptr-close></div>
+		<div class="uimptr-feature-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="uimptr-feature-modal-heading">
+			<button type="button" class="uimptr-feature-modal__close" data-uimptr-close aria-label="<?php esc_attr_e( 'Close', 'url-image-importer' ); ?>">
+				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+			</button>
+			<img class="uimptr-feature-modal__brand" src="<?php echo esc_url( $iu_wordmark ); ?>" alt="Infinite Uploads" width="132" height="33" />
+			<span class="uimptr-feature-modal__icon" id="uimptr-feature-modal-icon" aria-hidden="true"></span>
+			<h2 class="uimptr-feature-modal__heading" id="uimptr-feature-modal-heading"></h2>
+			<p class="uimptr-feature-modal__subtitle" id="uimptr-feature-modal-subtitle"></p>
+			<div class="uimptr-feature-modal__actions">
+				<?php if ( $action ) : ?>
+					<a class="uimptr-feature-modal__cta" href="<?php echo esc_url( $action['url'] ); ?>"<?php echo $action['external'] ? ' target="_blank" rel="noopener noreferrer"' : ''; ?>>
+						<span class="uimptr-feature-modal__cta-logo" aria-hidden="true">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
+						</span>
+						<?php echo esc_html( $action['label'] ); ?>
+					</a>
+				<?php else : ?>
+					<a class="uimptr-feature-modal__cta" href="<?php echo esc_url( $learn_more ); ?>" target="_blank" rel="noopener noreferrer">
+						<span class="uimptr-feature-modal__cta-logo" aria-hidden="true">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
+						</span>
+						<?php esc_html_e( 'Learn More About Infinite Uploads', 'url-image-importer' ); ?>
+					</a>
+				<?php endif; ?>
+			</div>
+			<p class="uimptr-feature-modal__note">
+				<?php
+					// translators: %s is a cloud icon.
+					printf( esc_html__( 'Get 7 days of %s storage, bandwidth, media folders, and more for FREE. Plans starting at just $8.25/mo.', 'url-image-importer' ), '<span class="dashicons dashicons-cloud" aria-hidden="true"></span>' );
+				?>
+			</p>
+		</div>
+	</div>
+	<script>
+	( function () {
+		var FEATURES = <?php echo wp_json_encode( $modal_features ); ?>;
+
+		var modal      = document.getElementById( 'uimptr-feature-modal' );
+		var iconEl     = document.getElementById( 'uimptr-feature-modal-icon' );
+		var headingEl  = document.getElementById( 'uimptr-feature-modal-heading' );
+		var subtitleEl = document.getElementById( 'uimptr-feature-modal-subtitle' );
+		var lastFocus  = null;
+
+		// The modal is printed inside the first import tab; move it to <body> so
+		// hiding that tab (display:none) never hides the fixed-position modal.
+		if ( modal && modal.parentNode !== document.body ) {
+			document.body.appendChild( modal );
+		}
+
+		function openModal( key ) {
+			var data = FEATURES[ key ];
+			if ( ! data || ! modal ) {
+				return;
+			}
+			iconEl.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' + data.icon + '</svg>';
+			headingEl.textContent  = data.heading;
+			subtitleEl.textContent = data.subtitle;
+			modal.classList.add( 'is-open' );
+			modal.setAttribute( 'aria-hidden', 'false' );
+			document.body.classList.add( 'uimptr-modal-open' );
+			var cta = modal.querySelector( '.uimptr-feature-modal__cta' );
+			if ( cta ) {
+				cta.focus();
+			}
+		}
+
+		function closeModal() {
+			if ( ! modal ) {
+				return;
+			}
+			modal.classList.remove( 'is-open' );
+			modal.setAttribute( 'aria-hidden', 'true' );
+			document.body.classList.remove( 'uimptr-modal-open' );
+			if ( lastFocus && lastFocus.focus ) {
+				lastFocus.focus();
+			}
+		}
+
+		// Cloud banner dismissal (persisted per browser).
+		var BANNER_KEY = 'uimptrCloudBannerDismissed';
+		function hideBanners() {
+			var banners = document.querySelectorAll( '.uimptr-cloud-banner' );
+			for ( var i = 0; i < banners.length; i++ ) {
+				banners[ i ].style.display = 'none';
+			}
+		}
+		try {
+			if ( window.localStorage && localStorage.getItem( BANNER_KEY ) === '1' ) {
+				hideBanners();
+			}
+		} catch ( err ) {}
+
+		document.addEventListener( 'click', function ( e ) {
+			if ( ! e.target.closest ) {
+				return;
+			}
+
+			var card = e.target.closest( '[data-uimptr-feature]' );
+			if ( card ) {
+				e.preventDefault();
+				lastFocus = card;
+				openModal( card.getAttribute( 'data-uimptr-feature' ) );
+				return;
+			}
+
+			if ( e.target.closest( '[data-uimptr-close]' ) ) {
+				e.preventDefault();
+				closeModal();
+				return;
+			}
+
+			if ( e.target.closest( '.uimptr-cloud-banner__dismiss' ) ) {
+				try {
+					if ( window.localStorage ) {
+						localStorage.setItem( BANNER_KEY, '1' );
+					}
+				} catch ( err ) {}
+				hideBanners();
+			}
+		} );
+
+		document.addEventListener( 'keydown', function ( e ) {
+			if ( e.key === 'Escape' && modal && modal.classList.contains( 'is-open' ) ) {
+				closeModal();
+			}
+		} );
+	} )();
+	</script>
+	<?php
+}
+
+/**
  * Import Image Form HTML
  */
 function uimptr_import_images_url_page() {
@@ -1110,6 +1421,7 @@ function uimptr_import_images_url_page() {
 				</div>
 			</div>
 		</form>
+		<?php uimptr_render_upsell_bar(); ?>
 	</div>
 
 	<!-- XML Import Form -->
@@ -1185,6 +1497,7 @@ function uimptr_import_images_url_page() {
 				</div>
 			</div>
 		</form>
+		<?php uimptr_render_upsell_bar(); ?>
 	</div>
 
 	<!-- CSV Import Section -->
@@ -1271,6 +1584,7 @@ function uimptr_import_images_url_page() {
 				</div>
 			</div>
 		</form>
+		<?php uimptr_render_upsell_bar(); ?>
 	</div>
 
 	<!-- Import Preview Modal -->

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -940,59 +940,11 @@ function uimptr_parse_image_urls_input( $raw ) {
 }
 
 /**
- * Resolve the Infinite Uploads install / activate / configure action.
- *
- * Mirrors the logic in templates/modal-upgrade.php so the upsell surfaces the
- * same one-click flow the plugin already uses for Infinite Uploads (the cloud
- * offloading successor to Big File Uploads):
- *  - not installed  -> core plugin installer (install-plugin)
- *  - installed only -> activation link
- *  - active         -> Infinite Uploads settings screen
- *
- * @return array{url:string,label:string,external:bool}|null Null when the user
- *               cannot install plugins.
- */
-function uimptr_get_infinite_uploads_action() {
-	if ( ! current_user_can( 'install_plugins' ) ) {
-		return null;
-	}
-
-	if ( ! function_exists( 'get_plugins' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-
-	$plugin_file       = 'infinite-uploads/infinite-uploads.php';
-	$installed_plugins = get_plugins();
-
-	if ( array_key_exists( $plugin_file, $installed_plugins ) ) {
-		if ( class_exists( 'Infinite_Uploads_Admin' ) ) {
-			return array(
-				'url'      => Infinite_Uploads_Admin::get_instance()->settings_url(),
-				'label'    => __( 'Configure Infinite Uploads', 'url-image-importer' ),
-				'external' => false,
-			);
-		}
-
-		return array(
-			'url'      => wp_nonce_url( 'plugins.php?action=activate&plugin=' . rawurlencode( $plugin_file ), 'activate-plugin_' . $plugin_file ),
-			'label'    => __( 'Activate Infinite Uploads', 'url-image-importer' ),
-			'external' => false,
-		);
-	}
-
-	return array(
-		'url'      => wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=infinite-uploads' ), 'install-plugin_infinite-uploads' ),
-		'label'    => __( 'Install Infinite Uploads', 'url-image-importer' ),
-		'external' => false,
-	);
-}
-
-/**
  * Render the Infinite Uploads Pro feature upsell grid.
  *
  * Rendered once per page, beneath the storage analysis section (not inside the
  * import tabs). Clicking a feature card opens a modal describing that feature
- * with a branded "Install Infinite Uploads" call to action.
+ * with a "Try Infinite Uploads" call to action that opens the pricing page.
  */
 function uimptr_render_upsell_bar() {
 	// Feather Icons (MIT) rendered inline so no extra assets are required.
@@ -1044,10 +996,11 @@ function uimptr_render_upsell_bar() {
 	// Feather "lock" icon reused for every Pro badge.
 	$lock_icon = '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>';
 
-	$action     = uimptr_get_infinite_uploads_action();
-	$learn_more = class_exists( 'UrlImageImporter\\Admin\\PromoNotices' )
-		? UrlImageImporter\Admin\PromoNotices::get_upgrade_url( 'feature_modal' )
-		: 'https://infiniteuploads.com/';
+	// Promotional CTAs point at the pricing page so the visitor can choose a
+	// plan, rather than triggering the plugin install/activate flow.
+	$pricing_url = class_exists( 'UrlImageImporter\\Admin\\PromoNotices' )
+		? UrlImageImporter\Admin\PromoNotices::get_pricing_url( 'upsell_banner' )
+		: 'https://infiniteuploads.com/pricing/';
 
 	// Official Infinite Uploads brand marks (bundled with the plugin).
 	$iu_logo_mark = plugins_url( 'assets/img/iu-logo-blue.svg', __FILE__ );
@@ -1081,17 +1034,10 @@ function uimptr_render_upsell_bar() {
 		<span class="uimptr-cloud-banner__content">
 			<span class="uimptr-cloud-banner__title"><?php esc_html_e( 'You can move your storage to Cloud on Infinite Uploads', 'url-image-importer' ); ?></span>
 			<span class="uimptr-cloud-banner__subtitle"><?php esc_html_e( 'Try out Infinite Uploads for Free for 7 days and upload your storage to the cloud.', 'url-image-importer' ); ?></span>
-			<?php if ( $action ) : ?>
-				<a class="uimptr-cloud-banner__cta" href="<?php echo esc_url( $action['url'] ); ?>">
+				<a class="uimptr-cloud-banner__cta" href="<?php echo esc_url( $pricing_url ); ?>" target="_blank" rel="noopener noreferrer">
 					<?php esc_html_e( 'Start Free', 'url-image-importer' ); ?>
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
 				</a>
-			<?php else : ?>
-				<a class="uimptr-cloud-banner__cta" href="<?php echo esc_url( $learn_more ); ?>" target="_blank" rel="noopener noreferrer">
-					<?php esc_html_e( 'Start Free', 'url-image-importer' ); ?>
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
-				</a>
-			<?php endif; ?>
 		</span>
 		<button type="button" class="uimptr-cloud-banner__dismiss" aria-label="<?php esc_attr_e( 'Dismiss', 'url-image-importer' ); ?>">
 			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
@@ -1128,15 +1074,9 @@ function uimptr_render_upsell_bar() {
 			<h2 class="uimptr-feature-modal__heading" id="uimptr-feature-modal-heading"></h2>
 			<p class="uimptr-feature-modal__subtitle" id="uimptr-feature-modal-subtitle"></p>
 			<div class="uimptr-feature-modal__actions">
-				<?php if ( $action ) : ?>
-					<a class="btn text-nowrap btn-primary btn-lg" href="<?php echo esc_url( $action['url'] ); ?>" role="button"<?php echo $action['external'] ? ' target="_blank" rel="noopener noreferrer"' : ''; ?>>
-						<?php echo esc_html( $action['label'] ); ?>
-					</a>
-				<?php else : ?>
-					<a class="btn text-nowrap btn-primary btn-lg" href="<?php echo esc_url( $learn_more ); ?>" role="button" target="_blank" rel="noopener noreferrer">
-						<?php esc_html_e( 'Learn More About Infinite Uploads', 'url-image-importer' ); ?>
-					</a>
-				<?php endif; ?>
+				<a class="btn text-nowrap btn-primary btn-lg" href="<?php echo esc_url( $pricing_url ); ?>" role="button" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Try Infinite Uploads', 'url-image-importer' ); ?>
+				</a>
 			</div>
 			<p class="uimptr-feature-modal__note">
 				<?php

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -821,7 +821,9 @@ function uimptr_admin_styles() {
 		wp_enqueue_style( 'uimptr-styles', plugins_url( 'assets/css/admin.css', __FILE__ ), '', $uimptr_admin_css_ver );
 		wp_enqueue_script( 'uimptr-chartjs', plugins_url( 'assets/js/Chart.min.js', __FILE__ ), '', UIMPTR_VERSION, true );
 		wp_enqueue_script( 'bfu-bootstrap', plugins_url( 'assets/bootstrap/js/bootstrap.bundle.min.js', __FILE__ ), '', UIMPTR_VERSION, true );
-		wp_enqueue_script( 'uimptr-js', plugins_url( 'assets/js/admin.js', __FILE__ ), '', UIMPTR_VERSION, true );
+		$uimptr_admin_js     = plugin_dir_path( __FILE__ ) . 'assets/js/admin.js';
+		$uimptr_admin_js_ver = file_exists( $uimptr_admin_js ) ? filemtime( $uimptr_admin_js ) : UIMPTR_VERSION;
+		wp_enqueue_script( 'uimptr-js', plugins_url( 'assets/js/admin.js', __FILE__ ), '', $uimptr_admin_js_ver, true );
 	}
 	$data                            = array();
 		$data['strings']             = array(
@@ -2404,9 +2406,10 @@ function uimptr_import_images_url_page() {
 	});
 	</script>
 	<?php
-	require_once UIMPTR_PATH . '/templates/modal-subscribe.php';
 	require_once UIMPTR_PATH . '/templates/modal-scan.php';
 
+	// Only include the subscribe modal until the user has subscribed or
+	// dismissed it, so re-running the scan does not ask for the email again.
 	$dismissed = get_user_option( 'bfu_subscribe_notice_dismissed', get_current_user_id() );
 	if ( ! $dismissed ) {
 		require_once UIMPTR_PATH . '/templates/modal-subscribe.php';


### PR DESCRIPTION
Rework the Infinite Uploads promotional surfaces in the URL Image Importer admin, in the Infinite Uploads brand.

## What changed
- **Upsell**: rendered once beneath the storage-analysis section (was duplicated inside every import tab); Pro feature grid + cloud banner.
- **Admin notice**: "Scale Your WordPress Media Library" card with brand accent bar; CTA "Try for Free".
- **Scan flow**: redesigned "Analyze Your Storage Usage" panel (progress ring, feature points), branded "Scanning" modal (cyan spinner), branded subscribe modal, and "Storage Usage Analysis" results panel (ring + file-type breakdown + Refresh + upgrade card).
- **Fixes**: no duplicate scan-start/results after a scan; don't re-prompt for the email on a re-scan; CTAs stay rounded on focus (WP core `a:focus` was squaring them).
- **CTAs → pricing**: Start Free, More Info, and the feature-modal button now link to the Infinite Uploads pricing page (`get_pricing_url`) instead of triggering the install/activate flow.
- Consistent use of the classic `.btn-primary` button; `admin.css`/`admin.js` versioned by filemtime for cache-busting.

## Tests
100 passing (434 assertions), incl. new PromoNotices pricing-URL coverage.

Deploy workflow is unaffected (runs on tags only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)