### PR TITLE
Release 1.2.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,14 @@
-=== URL Image Importer ===
+=== URL Image Importer – Import External Images to the Media Library from URL, CSV & XML ===
 Contributors: bww
-Tags: import image, image import, import image to media library, media library, csv import, xml import
+Tags: media library, image import, csv import, images, upload
 Requires at least: 5.3
 Tested up to: 7.0
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 Requires PHP: 7.4
 License: GPLv2 or higher
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Import images from URLs, CSV files, or WordPress XML exports directly into your WordPress Media Library to use across your entire site!
+Import external images into your WordPress Media Library from any URL, CSV, XML export, or Google Drive link. Bulk import, site migration ready.
 
 == Description ==
 
@@ -129,6 +129,13 @@ No. [Infinite Uploads](https://wordpress.org/plugins/infinite-uploads/) is an op
 3. Submit the form. If successful, the image(s) will be added to the Media Library, and you’ll get a link to edit them.
 
 == Changelog ==
+
+= 1.2.2 - 07/13/2026 =
+- Redesigned the storage analysis tool with a cleaner, more modern layout — run a free scan of your Media Library to see total usage and a breakdown by file type.
+- Refined the importer screens for a more polished, consistent interface.
+- Fixed: the storage analysis could display two panels at once after a scan finished.
+- Fixed: re-running a scan no longer re-prompts for your email once you've dismissed it.
+- Fixed: some buttons could lose their rounded corners after being clicked.
 
 = 1.2.1 - 06/13/2026 =
 - Improved ability to import large Google Drive images.

--- a/src/Core/Plugin.php
+++ b/src/Core/Plugin.php
@@ -28,7 +28,7 @@ class Plugin {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.2.1';
+	const VERSION = '1.2.2';
 
 	/**
 	 * Plugin directory path.

--- a/url-image-importer.php
+++ b/url-image-importer.php
@@ -3,14 +3,14 @@
  *
  * Plugin Name: URL Image Importer
  * Description: A plugin to import multiple images into the WordPress Media Library from URLs.
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: Infinite Uploads
  * Author URI: https://infiniteuploads.com
  * Text Domain: url-image-importer
  * License: GPL2
  *
  * @package UrlImageImporter
- * @version 1.2.1
+ * @version 1.2.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $upload_dir = wp_upload_dir();
 
 define( 'UIMPTR_PATH', plugin_dir_path( __FILE__ ) );
-define( 'UIMPTR_VERSION', '1.2.1' );
+define( 'UIMPTR_VERSION', '1.2.2' );
 
 define( 'UPLOADBLOGSDIR', $upload_dir['basedir'] );  // Use basedir for root uploads folder, not path (current month)
 define( 'UIMPTR_AJAX_NONCE_ACTION', 'uimptr_ajax' );


### PR DESCRIPTION
Version bump + changelog for the 1.2.2 release.

- Bumps version to 1.2.2 (plugin header, `UIMPTR_VERSION`, `Plugin::VERSION`).
- Adds the 1.2.2 changelog entry (storage-analysis redesign + fixes).
- Refreshes the WordPress.org listing header (title, tags, short description).

Tagging `1.2.2` after this merges will trigger the WordPress.org SVN deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)